### PR TITLE
feature: 상품 목록 조회, 좋아요 등록/취소, 주문 

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
     // querydsl
     kapt("com.querydsl:querydsl-apt::jakarta")
+    implementation ("com.querydsl:querydsl-jpa::jakarta")
+    implementation ("com.querydsl:querydsl-core")
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/brand/BrandFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/brand/BrandFacade.kt
@@ -1,0 +1,17 @@
+package com.loopers.application.brand
+
+import com.loopers.domain.brand.BrandService
+import com.loopers.interfaces.api.brand.BrandV1Models
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Component
+class BrandFacade(
+    private val brandService: BrandService
+) {
+
+    fun get(brandId: Long): BrandV1Models.Response.Info {
+        return BrandV1Models.Response.Info.of(brandService.getById(brandId))
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderFacade.kt
@@ -1,0 +1,38 @@
+package com.loopers.application.order
+
+import com.loopers.domain.order.OrderCommand
+import com.loopers.domain.order.OrderItemService
+import com.loopers.domain.order.OrderService
+import com.loopers.domain.order.StockService
+import com.loopers.domain.payment.PaymentService
+import com.loopers.domain.product.ProductHistoryService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Component
+class OrderFacade(
+    private val productHistoryService: ProductHistoryService,
+    private val orderService: OrderService,
+    private val orderItemService: OrderItemService,
+    private val stockService: StockService,
+    private val paymentService: PaymentService,
+
+    ) {
+
+    @Transactional
+    fun create(command: OrderCommand.Create) {
+        val products = productHistoryService.getProductsForOrder(command.items.map { it.productId })
+        val productIds = products.map { it.productId }
+
+        //주문 생성
+        val orderId = orderService.create(command)
+        val orderItems = orderItemService.create(command.items, orderId, products)
+
+        //결제
+        paymentService.charge(command.userId, command.paymentType, orderItems)
+
+        //재고
+        stockService.changeStock(command, productIds)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderFacade.kt
@@ -4,6 +4,7 @@ import com.loopers.domain.order.OrderCommand
 import com.loopers.domain.order.OrderItemService
 import com.loopers.domain.order.OrderService
 import com.loopers.domain.order.StockService
+import com.loopers.domain.payment.PaymentCommand
 import com.loopers.domain.payment.PaymentService
 import com.loopers.domain.product.ProductHistoryService
 import org.springframework.stereotype.Component
@@ -21,18 +22,18 @@ class OrderFacade(
     ) {
 
     @Transactional
-    fun create(command: OrderCommand.Create) {
-        val products = productHistoryService.getProductsForOrder(command.items.map { it.productId })
+    fun create(orderCommand: OrderCommand.Create, paymentCommand: PaymentCommand.Create) {
+        val products = productHistoryService.getProductsForOrder(orderCommand.items.map { it.productId })
         val productIds = products.map { it.productId }
 
         //주문 생성
-        val orderId = orderService.create(command)
-        val orderItems = orderItemService.create(command.items, orderId, products)
+        val orderId = orderService.create(orderCommand)
+        val orderItems = orderItemService.create(orderCommand.items, orderId, products)
 
         //결제
-        paymentService.charge(command.userId, command.paymentType, orderItems)
+        paymentService.charge(orderCommand.userId, orderItems, paymentCommand)
 
         //재고
-        stockService.changeStock(command, productIds)
+        stockService.changeStock(orderCommand, productIds)
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointFacade.kt
@@ -3,7 +3,7 @@ package com.loopers.application.point
 import com.loopers.domain.point.PointCommand
 import com.loopers.domain.point.PointService
 import com.loopers.domain.user.UserService
-import com.loopers.interfaces.api.point.PointV1Dto
+import com.loopers.interfaces.api.point.PointV1Models
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
 import org.springframework.stereotype.Component
@@ -16,14 +16,14 @@ class PointFacade(
 ) {
 
     @Transactional(readOnly = true)
-    fun get(userId: String): PointV1Dto.Response.PointResponse {
+    fun get(userId: String): PointV1Models.Response.Get {
         val pointInfo = pointService.findByUserId(userId) ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID,"존재하지 않는 사용자 ID 입니다. 사용자 ID: ${userId}")
-        return pointInfo.let { PointV1Dto.Response.PointResponse.of(it) }
+        return pointInfo.let { PointV1Models.Response.Get.of(it) }
     }
 
     @Transactional
-    fun charge(command: PointCommand.ChargeInput): PointV1Dto.Response.ChargeResponse {
+    fun charge(command: PointCommand.ChargeInput): PointV1Models.Response.Charge {
         userService.findByUserId(command.userId) ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID,"존재하지 않는 사용자 ID 입니다. 사용자 ID: ${command.userId}")
-        return pointService.charge(command).let { PointV1Dto.Response.ChargeResponse.of(it) }
+        return pointService.charge(command).let { PointV1Models.Response.Charge.of(it) }
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt
@@ -1,0 +1,47 @@
+package com.loopers.application.product
+
+import com.loopers.domain.product.ProductCommand
+import com.loopers.domain.product.ProductLikeService
+import com.loopers.domain.product.ProductService
+import com.loopers.domain.user.UserService
+import com.loopers.interfaces.api.product.ProductV1Models
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.data.domain.Page
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Component
+class ProductFacade(
+    private val productService: ProductService,
+    private val productLikeService: ProductLikeService,
+    private val userService: UserService,
+) {
+
+    fun get(productId: Long): ProductV1Models.Response.GetInfo {
+        val source = productService.getWithBrand(productId)
+        return ProductV1Models.Response.GetInfo.of(source)
+    }
+
+    fun getList(command: ProductCommand.QueryCriteria): Page<ProductV1Models.Response.GetList> {
+        val sourcePage = productService.getList(command)
+        return sourcePage.map { ProductV1Models.Response.GetList.of(it) }
+    }
+
+    @Transactional
+    fun like(command: ProductCommand.Like) {
+        userService.findByUserId(command.userId) ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID,"존재하지 않는 사용자 ID 입니다. 사용자 ID: ${command.userId}")
+        if (productLikeService.create(command)) {
+            productService.like(command.productId)
+        }
+    }
+
+    @Transactional
+    fun deleteLike(command: ProductCommand.Like) {
+        userService.findByUserId(command.userId) ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID,"존재하지 않는 사용자 ID 입니다. 사용자 ID: ${command.userId}")
+        if (productLikeService.delete(command)) {
+            productService.decreaseLike(command.productId)
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserFacade.kt
@@ -2,7 +2,7 @@ package com.loopers.application.user
 
 import com.loopers.domain.user.UserCommand
 import com.loopers.domain.user.UserService
-import com.loopers.interfaces.api.user.UserV1Dto
+import com.loopers.interfaces.api.user.UserV1Models
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
 import org.springframework.stereotype.Component
@@ -14,18 +14,18 @@ class UserFacade(
 ) {
 
     @Transactional
-    fun signUp(command: UserCommand.Create): UserV1Dto.Response.UserResponse {
+    fun signUp(command: UserCommand.Create): UserV1Models.Response.Info {
 
         userService.findByUserId(command.userId)?.let {
             throw CoreException(ErrorType.CONFLICT, "이미 회원가입된 사용자입니다.")
         }
 
-        return UserV1Dto.Response.UserResponse.of(userService.create(command))
+        return UserV1Models.Response.Info.of(userService.create(command))
     }
 
     @Transactional(readOnly = true)
-    fun getMyInfo(userId: String): UserV1Dto.Response.UserResponse =
+    fun getMyInfo(userId: String): UserV1Models.Response.Info =
         userService.findByUserId(userId)
-            ?.let(UserV1Dto.Response.UserResponse::of)
+            ?.let(UserV1Models.Response.Info::of)
             ?: throw CoreException(ErrorType.NOT_EXIST_USER)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandDtos.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandDtos.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.brand
+
+data class BrandGetDto(
+    val id: Long,
+    val name: String,
+) {
+    companion object {
+        fun of(source: BrandEntity): BrandGetDto {
+            return BrandGetDto(
+                id = source.id,
+                name = source.name
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandEntity.kt
@@ -1,0 +1,16 @@
+package com.loopers.domain.brand
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "brand")
+class BrandEntity(
+    name: String,
+): BaseEntity() {
+
+    @Column(name = "name")
+    val name: String = name
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandRepository.kt
@@ -1,0 +1,12 @@
+package com.loopers.domain.brand
+
+import com.loopers.interfaces.api.brand.BrandV1Models
+
+
+interface BrandRepository {
+
+    fun save(brand: BrandEntity): BrandEntity
+
+    fun findById(id: Long): BrandEntity?
+
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandService.kt
@@ -1,0 +1,18 @@
+package com.loopers.domain.brand
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class BrandService(
+    private val brandRepository: BrandRepository
+) {
+
+    fun getById(brandId: Long): BrandGetDto {
+        val brand = brandRepository.findById(brandId) ?: throw CoreException(ErrorType.NOT_FOUND, "존재하지 않는 브랜드입니다.")
+        return BrandGetDto.of(brand)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderCommand.kt
@@ -10,8 +10,7 @@ class OrderCommand {
 
     data class Create(
         val userId: String,
-        val items: List<Item>,
-        val paymentType: PaymentType
+        val items: List<Item>
     )
 
     data class Item(

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderCommand.kt
@@ -1,0 +1,36 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.type.PaymentType
+import com.loopers.interfaces.api.order.OrderV1Models
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import java.math.BigDecimal
+
+class OrderCommand {
+
+    data class Create(
+        val userId: String,
+        val items: List<Item>,
+        val paymentType: PaymentType
+    )
+
+    data class Item(
+        val productId: Long,
+        val price: BigDecimal,
+        val qty: Int,
+    ) {
+
+        init {
+            require(qty > 0) { throw CoreException(ErrorType.QTY_MUST_BE_POSITIVE) }
+            require(price > BigDecimal.ZERO) { throw CoreException(ErrorType.PRICE_MUST_BE_POSITIVE) }
+        }
+
+        companion object {
+            fun of(request: OrderV1Models.Request.Item) = Item(
+                productId = request.productId,
+                price = request.price,
+                qty = request.qty
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderDtos.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderDtos.kt
@@ -1,0 +1,51 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.type.OrderItemStatus
+import com.loopers.domain.type.OrderStatus
+import java.math.BigDecimal
+
+data class OrderDto(
+    val totalPrice: BigDecimal,
+    val status: OrderStatus,
+    val canceledPrice: BigDecimal,
+    val submittedPrice: BigDecimal,
+    val items: List<OrderItemDto> = emptyList(),
+)
+
+data class OrderItemDto(
+    val id: Long,
+    val orderId: Long,
+    val productHistoryId: Long,
+    val unitPrice: BigDecimal,
+    val totalPrice: BigDecimal,
+    val qty: Int,
+    val status: OrderItemStatus,
+) {
+    companion object {
+        fun of(source: OrderItemEntity) = OrderItemDto(
+            id = source.id,
+            orderId = source.orderId,
+            productHistoryId = source.productHistoryId,
+            unitPrice = source.unitPrice,
+            totalPrice = source.totalPrice,
+            qty = source.qty,
+            status = source.status,
+        )
+    }
+}
+
+interface IErrorIdsDto {
+    var ids: MutableList<Long>
+}
+
+data class ProductErrorDto(
+    override var ids: MutableList<Long> = mutableListOf()
+) : IErrorIdsDto
+
+data class StockErrorDto(
+    override var ids: MutableList<Long> = mutableListOf()
+) : IErrorIdsDto
+
+data class PaymentErrorDto(
+    override var ids: MutableList<Long> = mutableListOf()
+) : IErrorIdsDto

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderEntity.kt
@@ -1,0 +1,45 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.BaseEntity
+import com.loopers.domain.type.OrderStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "shop_order")
+class OrderEntity(
+    userId: String,
+    totalPrice: BigDecimal,
+    status: OrderStatus = OrderStatus.ORDERED,
+    canceledPrice: BigDecimal? = null,
+    submittedPrice: BigDecimal,
+): BaseEntity() {
+
+    @Column(name = "userId")
+    val userId: String = userId
+
+    @Column(name = "total_price")
+    val totalPrice: BigDecimal = totalPrice
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    val status: OrderStatus = status
+
+    @Column(name = "canceled_price")
+    val canceledPrice: BigDecimal? = canceledPrice
+
+    @Column(name = "submitted_price")
+    val submittedPrice: BigDecimal? = submittedPrice
+
+    companion object {
+        fun of(userId: String, totalPrice: BigDecimal) = OrderEntity(
+            userId = userId,
+            totalPrice = totalPrice,
+            submittedPrice = totalPrice
+        )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemEntity.kt
@@ -6,6 +6,9 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.math.BigDecimal
 
@@ -22,6 +25,10 @@ class OrderItemEntity(
 
     @Column(name = "order_id")
     val orderId: Long = orderId
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", insertable = false, updatable = false)
+    var order: OrderEntity? = null
 
     @Column(name = "product_history_id")
     val productHistoryId: Long = productHistoryId

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemEntity.kt
@@ -1,0 +1,53 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.BaseEntity
+import com.loopers.domain.type.OrderItemStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "order_item")
+class OrderItemEntity(
+    orderId: Long,
+    productHistoryId: Long,
+    unitPrice: BigDecimal,
+    totalPrice: BigDecimal,
+    qty: Int,
+    status: OrderItemStatus = OrderItemStatus.ORDERED
+): BaseEntity() {
+
+    @Column(name = "order_id")
+    val orderId: Long = orderId
+
+    @Column(name = "product_history_id")
+    val productHistoryId: Long = productHistoryId
+
+    @Column(name = "unit_price")
+    val unitPrice: BigDecimal = unitPrice
+
+    @Column(name = "total_price")
+    val totalPrice: BigDecimal = totalPrice
+
+    @Column(name = "qty")
+    val qty: Int = qty
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    var status: OrderItemStatus = status
+
+    companion object {
+        fun of(command: OrderCommand.Item, orderId: Long, productHistoryId: Long): OrderItemEntity {
+            return OrderItemEntity(
+                orderId = orderId,
+                productHistoryId = productHistoryId,
+                unitPrice = command.price,
+                totalPrice = command.price.multiply(BigDecimal.valueOf(command.qty.toLong())),
+                qty = command.qty
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.order
+
+interface OrderItemRepository {
+
+    fun saveAll(orderItemEntities: List<OrderItemEntity>)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderItemService.kt
@@ -1,0 +1,23 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.product.ProductHistoryDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+@Transactional(readOnly = true)
+@Service
+class OrderItemService(
+    private val orderItemRepository: OrderItemRepository
+) {
+
+    @Transactional
+    fun create(commands: List<OrderCommand.Item>, orderId: Long, products: List<ProductHistoryDto>): List<OrderItemDto> {
+        val productIdToDto = products.associateBy { it.productId }
+
+        val orderItems = commands.map { command ->
+            val product = productIdToDto[command.productId]!!
+            OrderItemEntity.of(command, orderId, product.productHistoryId)
+        }
+        orderItemRepository.saveAll(orderItems)
+        return orderItems.map { OrderItemDto.of(it) }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.order
+
+interface OrderRepository {
+
+    fun save(order: OrderEntity): OrderEntity
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderService.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.order
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Transactional(readOnly = true)
+@Service
+class OrderService(
+    private val orderRepository: OrderRepository,
+) {
+
+    @Transactional
+    fun create(command: OrderCommand.Create): Long {
+        val totalPrice = command.items
+            .map { it.price.multiply(BigDecimal.valueOf(it.qty.toLong())) }
+            .reduce { totalValue, price -> totalValue + price }
+        return orderRepository.save(OrderEntity.of(command.userId, totalPrice)).id
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/StockService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/StockService.kt
@@ -1,0 +1,44 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.product.ProductEntity
+import com.loopers.domain.product.ProductHistoryEntity
+import com.loopers.domain.product.ProductHistoryRepository
+import com.loopers.domain.product.ProductRepository
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class StockService(
+    private val productRepository: ProductRepository,
+    private val productHistoryRepository: ProductHistoryRepository,
+) {
+
+    @Transactional
+    fun changeStock(command: OrderCommand.Create, productIds: List<Long>) {
+        val idToProduct = productRepository.findByIdIn(productIds).associateBy { it.id }
+
+        val updatedProducts = command.items.map { command ->
+            val product = idToProduct[command.productId] ?: throw CoreException(ErrorType.PRODUCT_NOT_FOUND, "상품이 존재하지 않습니다. id=${command.productId}")
+            updateStock(product, command.qty)
+            product
+        }
+        //고민되는 부분 주문 생성했을때와 재고 차감했을때의 history가 다르다.
+        val hitories = updatedProducts.map { ProductHistoryEntity.of(it) }
+        productRepository.saveAll(updatedProducts)
+        productHistoryRepository.saveAll(hitories)
+    }
+
+    fun updateStock(product: ProductEntity, qty: Int) {
+        validateStock(product.stock, qty)
+        product.updateStock(qty)
+    }
+
+    //고민 부분 , update만 넣을 것인지 따로 분리할껏인지
+    fun validateStock(stock: Int, qty: Int) {
+        if (stock < qty) {
+            throw CoreException(ErrorType.OUT_OF_STOCK)
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/StockService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/StockService.kt
@@ -24,7 +24,7 @@ class StockService(
             updateStock(product, command.qty)
             product
         }
-        //고민되는 부분 주문 생성했을때와 재고 차감했을때의 history가 다르다.
+
         val hitories = updatedProducts.map { ProductHistoryEntity.of(it) }
         productRepository.saveAll(updatedProducts)
         productHistoryRepository.saveAll(hitories)
@@ -35,7 +35,6 @@ class StockService(
         product.updateStock(qty)
     }
 
-    //고민 부분 , update만 넣을 것인지 따로 분리할껏인지
     fun validateStock(stock: Int, qty: Int) {
         if (stock < qty) {
             throw CoreException(ErrorType.OUT_OF_STOCK)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/IPaymentCharger.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/IPaymentCharger.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.order.OrderItemDto
+
+interface IPaymentCharger {
+
+    fun charge(userId: String, orderItems: List<OrderItemDto>)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/IPaymentCharger.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/IPaymentCharger.kt
@@ -1,8 +1,0 @@
-package com.loopers.domain.payment
-
-import com.loopers.domain.order.OrderItemDto
-
-interface IPaymentCharger {
-
-    fun charge(userId: String, orderItems: List<OrderItemDto>)
-}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/IPaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/IPaymentProcessor.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.type.PaymentType
+import java.math.BigDecimal
+
+interface IPaymentProcessor {
+    fun supportType(): PaymentType
+    fun charge(userId: String, amount: BigDecimal)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentCommand.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.type.PaymentType
+import com.loopers.interfaces.api.order.OrderV1Models
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import java.math.BigDecimal
+
+class PaymentCommand {
+
+    data class Create(
+        val payments: List<Payment>
+    )
+
+    data class Payment(
+        val type: PaymentType,
+        val amount: BigDecimal,
+    ) {
+        init {
+            require(amount > BigDecimal.ZERO) { throw CoreException(ErrorType.INVALID_PAYMENT_PRICE) }
+        }
+
+        companion object {
+            fun of(request: OrderV1Models.Request.Payment) = Payment(
+                type = request.type,
+                amount = request.amount,
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
@@ -1,0 +1,22 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.order.OrderItemDto
+import com.loopers.domain.type.PaymentType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class PaymentService(
+    private val pointCharger: PointCharger
+) {
+
+    fun charge(userId: String, type: PaymentType, orderItems: List<OrderItemDto>) {
+
+        val payCharger: IPaymentCharger = when (type) {
+            PaymentType.POINT -> pointCharger
+            PaymentType.CARD -> pointCharger //TODO 추후 pg사 연결
+        }
+        payCharger.charge(userId, orderItems)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
@@ -1,22 +1,37 @@
 package com.loopers.domain.payment
 
 import com.loopers.domain.order.OrderItemDto
-import com.loopers.domain.type.PaymentType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
 
-@Transactional(readOnly = true)
 @Service
 class PaymentService(
-    private val pointCharger: PointCharger
+    private val processors: List<IPaymentProcessor>
 ) {
 
-    fun charge(userId: String, type: PaymentType, orderItems: List<OrderItemDto>) {
+    @Transactional
+    fun charge(userId: String, orderItems: List<OrderItemDto>, paymentRequest: PaymentCommand.Create) {
+        validateTotalPrice(orderItems.sumOf { it.totalPrice }, paymentRequest.payments.sumOf { it.amount })
+        paymentRequest.payments.forEach { request ->
+            val processor = processors.find { it.supportType() == request.type }
+                ?: throw CoreException(
+                    ErrorType.INVALID_PAYMENT_TYPE,
+                    "지원하지 않는 결제 수단입니다: ${request.type}"
+                )
 
-        val payCharger: IPaymentCharger = when (type) {
-            PaymentType.POINT -> pointCharger
-            PaymentType.CARD -> pointCharger //TODO 추후 pg사 연결
+            processor.charge(userId, request.amount)
         }
-        payCharger.charge(userId, orderItems)
+    }
+
+    fun validateTotalPrice(totalOrderPrice: BigDecimal, totalPaymentAmount: BigDecimal) {
+        if (totalOrderPrice != totalPaymentAmount) {
+            throw CoreException(
+                ErrorType.INVALID_PAYMENT_PRICE,
+                "결제 금액이 총 주문 금액과 일치하지 않습니다. 주문 금액: $totalOrderPrice, 결제 총액: $totalPaymentAmount"
+            )
+        }
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PointCharger.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PointCharger.kt
@@ -1,0 +1,41 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.order.OrderItemDto
+import com.loopers.domain.point.PointEntity
+import com.loopers.domain.point.PointRepository
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Component
+class PointCharger(
+    private val pointRepository: PointRepository
+): IPaymentCharger {
+
+    @Transactional
+    override fun charge(
+        userId: String,
+        orderItems: List<OrderItemDto>,
+    ) {
+        val point = pointRepository.findByUserId(userId) ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID,"포인트가 없는 사용자 입니다. 사용자 ID: ${userId}")
+        val totalPrice = orderItems.sumOf { it.totalPrice }
+        validatePoint(point.amount, totalPrice)
+        updatePoint(point, totalPrice)
+    }
+
+    fun updatePoint(point: PointEntity, totalPrice: BigDecimal) {
+        val currentPoint = point.amount.minus(totalPrice)
+        point.updateAmount(currentPoint)
+        pointRepository.save(point)
+    }
+
+    fun validatePoint(point: BigDecimal, totalPrice: BigDecimal) {
+        if(totalPrice == BigDecimal.ZERO) return
+
+        if(point < totalPrice) {
+            throw CoreException(ErrorType.NOT_ENOUGH_POINTS, "포인트가 부족합니다. 결제액 : $totalPrice, 포인트 : $point")
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PointPaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PointPaymentProcessor.kt
@@ -1,8 +1,8 @@
 package com.loopers.domain.payment
 
-import com.loopers.domain.order.OrderItemDto
 import com.loopers.domain.point.PointEntity
 import com.loopers.domain.point.PointRepository
+import com.loopers.domain.type.PaymentType
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
 import org.springframework.stereotype.Component
@@ -10,19 +10,20 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Component
-class PointCharger(
+class PointPaymentProcessor(
     private val pointRepository: PointRepository
-): IPaymentCharger {
+): IPaymentProcessor {
+
+    override fun supportType(): PaymentType = PaymentType.POINT
 
     @Transactional
     override fun charge(
         userId: String,
-        orderItems: List<OrderItemDto>,
+        amount: BigDecimal,
     ) {
         val point = pointRepository.findByUserId(userId) ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID,"포인트가 없는 사용자 입니다. 사용자 ID: ${userId}")
-        val totalPrice = orderItems.sumOf { it.totalPrice }
-        validatePoint(point.amount, totalPrice)
-        updatePoint(point, totalPrice)
+        validatePoint(point.amount, amount)
+        updatePoint(point, amount)
     }
 
     fun updatePoint(point: PointEntity, totalPrice: BigDecimal) {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointCommand.kt
@@ -2,12 +2,13 @@ package com.loopers.domain.point
 
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
+import java.math.BigDecimal
 
 class PointCommand {
 
     data class PointInfo(
         val userId: String,
-        val amount: Long,
+        val amount: BigDecimal,
     ) {
 
         companion object {
@@ -20,17 +21,17 @@ class PointCommand {
 
     data class ChargeInput(
         val userId: String,
-        val amount: Long,
+        val amount: BigDecimal,
     ) {
 
         init {
-            require(amount > 0) {
+            require(amount > BigDecimal.ZERO) {
                 throw CoreException(ErrorType.CHARGE_AMOUNT_MUST_BE_POSITIVE)
             }
         }
 
         companion object {
-            fun of(userId: String, amount: Long) = ChargeInput (
+            fun of(userId: String, amount: BigDecimal) = ChargeInput (
                 userId = userId,
                 amount = amount,
             )

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointEntity.kt
@@ -4,12 +4,13 @@ import com.loopers.domain.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.math.BigDecimal
 
 @Entity
 @Table(name = "point")
 class PointEntity(
     userId: String,
-    amount: Long = 0,
+    amount: BigDecimal = BigDecimal.ZERO,
 ) : BaseEntity() {
     @Column(name = "user_id", unique = true, nullable = false)
     var userId = userId
@@ -19,7 +20,7 @@ class PointEntity(
     var amount = amount
         private set
 
-    fun updateAmount(amount: Long) {
+    fun updateAmount(amount: BigDecimal) {
         this.amount = amount
     }
 

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductCommand.kt
@@ -1,0 +1,17 @@
+package com.loopers.domain.product
+
+import org.springframework.data.domain.Pageable
+
+class ProductCommand {
+
+    data class QueryCriteria(
+        val brandIds: List<Long>,
+        val productId: Long?,
+        val pageable: Pageable
+    )
+
+    data class Like (
+        val productId: Long,
+        val userId: String,
+    )
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductDtos.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductDtos.kt
@@ -1,0 +1,61 @@
+package com.loopers.domain.product
+
+import java.math.BigDecimal
+
+data class ProductHistoryDto(
+    val productId: Long,
+    val productHistoryId: Long,
+    val productName: String,
+    val brandId: Long,
+    val stock: Int,
+    val likeCount: Int
+) {
+    companion object {
+        fun of(source: ProductHistoryEntity) = ProductHistoryDto(
+            productId = source.productId,
+            productHistoryId = source.id,
+            productName = source.name,
+            brandId = source.brandId,
+            stock = source.stock,
+            likeCount = source.likeCount
+        )
+    }
+}
+
+data class ProductWithBrandDto(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val brandName: String,
+    val stock: Int,
+    val likeCount: Int,
+    val price: BigDecimal
+) {
+    companion object {
+        fun of(source: ProductEntity): ProductWithBrandDto {
+            return ProductWithBrandDto(
+                productId = source.id,
+                productName = source.name,
+                brandId = source.brandId,
+                brandName = source.brand!!.name,
+                stock = source.stock,
+                likeCount = source.likeCount,
+                price = source.price
+            )
+        }
+    }
+}
+
+data class ProductListGetDto(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val brandName: String,
+    val likeCount: Int,
+    val price: BigDecimal
+)
+
+data class ProductLikeDto(
+    val productId: Long,
+    val userId: String,
+)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductEntity.kt
@@ -1,0 +1,46 @@
+package com.loopers.domain.product
+
+import com.loopers.domain.BaseEntity
+import com.loopers.domain.brand.BrandEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "product")
+class ProductEntity(
+    name: String,
+    brandId: Long,
+    price: BigDecimal,
+    stock: Int = 0,
+    likeCount: Int = 0,
+) : BaseEntity() {
+
+    @Column(name = "name")
+    val name: String = name
+
+    @Column(name = "brand_id")
+    var brandId: Long = brandId
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id", insertable = false, updatable = false)
+    var brand: BrandEntity? = null
+
+    @Column(name = "price")
+    val price: BigDecimal = price
+
+    @Column(name = "stock")
+    var stock: Int = stock
+
+    @Column(name = "like_count")
+    var likeCount: Int = likeCount
+
+    fun updateStock(qty: Int) {
+        stock -= qty
+    }
+}
+

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryEntity.kt
@@ -1,0 +1,42 @@
+package com.loopers.domain.product
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "product_history")
+class ProductHistoryEntity(
+    productId: Long,
+    name: String,
+    brandId: Long,
+    stock: Int = 0,
+    likeCount: Int = 0,
+): BaseEntity() {
+
+    @Column(name = "product_id")
+    val productId: Long = productId
+
+    @Column(name = "name")
+    val name: String = name
+
+    @Column(name = "brand_id")
+    val brandId: Long = brandId
+
+    @Column(name = "stock")
+    var stock: Int = stock
+
+    @Column(name = "like_count")
+    var likeCount: Int = likeCount
+
+    companion object {
+        fun of(product: ProductEntity): ProductHistoryEntity {
+            return ProductHistoryEntity(
+                product.id,
+                product.name,
+                product.brandId,
+                product.likeCount)
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.product
+
+interface ProductHistoryRepository {
+
+    fun saveAll(productHistory: List<ProductHistoryEntity>): List<ProductHistoryEntity>
+
+    fun findProductIdToHistoryByProductIds(productIds: Collection<Long>): List<ProductHistoryEntity>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryService.kt
@@ -1,0 +1,29 @@
+package com.loopers.domain.product
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class ProductHistoryService(
+    private val productHistoryRepository: ProductHistoryRepository
+) {
+
+    fun getProductsForOrder(productIds: List<Long>): List<ProductHistoryDto> {
+        val productHistory = productHistoryRepository.findProductIdToHistoryByProductIds(productIds)
+        validateUnExistedProduct(productIds, productHistory.map { it.productId })
+        return productHistory.map { ProductHistoryDto.of(it) }
+    }
+
+    //서비스 내에서 해야할까
+    fun validateUnExistedProduct(reqProductIds: Collection<Long>, findProductIds: Collection<Long>) {
+        val foundIds = findProductIds
+        val missingIds = reqProductIds.filterNot { it in foundIds }
+
+        if (missingIds.isNotEmpty()) {
+            throw CoreException(ErrorType.PRODUCT_NOT_FOUND, "존재하지 않는 상품 ID: $missingIds")
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductHistoryService.kt
@@ -17,7 +17,6 @@ class ProductHistoryService(
         return productHistory.map { ProductHistoryDto.of(it) }
     }
 
-    //서비스 내에서 해야할까
     fun validateUnExistedProduct(reqProductIds: Collection<Long>, findProductIds: Collection<Long>) {
         val foundIds = findProductIds
         val missingIds = reqProductIds.filterNot { it in foundIds }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductLikeEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductLikeEntity.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.product
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "product_like")
+class ProductLikeEntity(
+    userId: String,
+    productId: Long
+) : BaseEntity() {
+
+    @Column(name = "user_id")
+    val userId = userId
+
+    @Column(name = "product_id")
+    val productId = productId
+
+    companion object {
+
+        fun of(command: ProductCommand.Like): ProductLikeEntity {
+            return ProductLikeEntity(
+                userId = command.userId,
+                productId = command.productId,
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductLikeRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductLikeRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.product
+
+interface ProductLikeRepository {
+
+    fun findByUserIdAndProductId(userId: String, productId: Long): ProductLikeEntity?
+    fun findByUserId(userId: String): List<ProductLikeEntity>
+    fun save(entity: ProductLikeEntity)
+    fun delete(entity: ProductLikeEntity)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductLikeService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductLikeService.kt
@@ -1,0 +1,29 @@
+package com.loopers.domain.product
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class ProductLikeService(
+    private val productLikeRepository: ProductLikeRepository,
+) {
+
+    @Transactional
+    fun create(command: ProductCommand.Like): Boolean {
+        productLikeRepository.findByUserIdAndProductId(command.userId, command.productId)?.let { return false }
+        ProductLikeEntity.of(command).apply { productLikeRepository.save(this) }.let { return true }
+    }
+
+    @Transactional
+    fun delete(command: ProductCommand.Like): Boolean {
+        val productLike = productLikeRepository.findByUserIdAndProductId(command.userId, command.productId)
+            ?: return false
+        productLikeRepository.delete(productLike)
+        return true
+    }
+
+    fun getMyLikes(userId: String): List<ProductLikeDto> {
+        return productLikeRepository.findByUserId(userId).map { ProductLikeDto(it.productId, it.userId) }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductRepository.kt
@@ -1,0 +1,22 @@
+package com.loopers.domain.product
+
+import org.springframework.data.domain.Page
+
+interface ProductRepository {
+
+    fun save(product: ProductEntity): ProductEntity
+
+    fun saveAll(product: List<ProductEntity>): List<ProductEntity>
+
+    fun findById(productId: Long): ProductEntity
+
+    fun findListByCriteria(command: ProductCommand.QueryCriteria): Page<ProductListGetDto>
+
+    fun findByIdIn(ids: Collection<Long>): List<ProductEntity>
+
+    fun getWithBrandById(id: Long): ProductEntity
+
+    fun incrementLikeCount(productId: Long): Int
+
+    fun decrementLikeCount(productId: Long)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductService.kt
@@ -1,0 +1,35 @@
+package com.loopers.domain.product
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.data.domain.Page
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class ProductService(
+    val productRepository: ProductRepository,
+) {
+
+    fun getList(command: ProductCommand.QueryCriteria): Page<ProductListGetDto> {
+        return productRepository.findListByCriteria(command)
+    }
+
+    fun getWithBrand(productId: Long): ProductWithBrandDto {
+        val product = productRepository.getWithBrandById(productId)
+        return ProductWithBrandDto.of(product)
+    }
+
+    @Transactional
+    fun like(productId: Long) {
+        val product = productRepository.findById(productId)
+        productRepository.incrementLikeCount(product.id)
+    }
+
+    @Transactional
+    fun decreaseLike(productId: Long) {
+        val product = productRepository.findById(productId)
+        productRepository.decrementLikeCount(product.id)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/type/OrderTypes.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/type/OrderTypes.kt
@@ -1,0 +1,25 @@
+package com.loopers.domain.type
+
+enum class OrderStatus(
+    val description: String,
+) {
+    ORDERED("주문 생성"),
+    PAID("결제 완료"),
+    CANCELLED("주문 취소"),
+    FAILED("주문 실패")
+}
+
+enum class OrderItemStatus(
+    val description: String,
+) {
+    ORDERED("상품 주문"),
+    CANCELLED("상품 취소"),
+    FAILED("주문 실패")
+}
+
+enum class PaymentType(
+    val description: String,
+) {
+    POINT("포인트 결제"),
+    CARD("카드결제")
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserRepository.kt
@@ -1,6 +1,6 @@
 package com.loopers.domain.user
 
 interface UserRepository {
-    fun save(user: UserEntity)
+    fun save(user: UserEntity): UserEntity
     fun findByUserId(userId: String): UserEntity?
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandJpaRepository.kt
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.brand
+
+import com.loopers.domain.brand.BrandEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BrandJpaRepository : JpaRepository<BrandEntity, Long> {
+
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.brand
+
+import com.loopers.domain.brand.BrandEntity
+import com.loopers.domain.brand.BrandRepository
+import org.springframework.stereotype.Component
+
+@Component
+class BrandRepositoryImpl(
+    private val brandJpaRepository: BrandJpaRepository
+): BrandRepository {
+
+    override fun save(brand: BrandEntity): BrandEntity {
+        return brandJpaRepository.save(brand)
+    }
+
+    override fun findById(id: Long): BrandEntity? {
+        return brandJpaRepository.findById(id).orElse(null)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderItemJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderItemJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.order
+
+import com.loopers.domain.order.OrderItemEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OrderItemJpaRepository: JpaRepository<OrderItemEntity, Long> {
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderItemRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderItemRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.order
+
+import com.loopers.domain.order.OrderItemEntity
+import com.loopers.domain.order.OrderItemRepository
+import org.springframework.stereotype.Component
+
+@Component
+class OrderItemRepositoryImpl(
+    private val orderItemJpaRepository: OrderItemJpaRepository
+): OrderItemRepository {
+
+    override fun saveAll(orderItemEntities: List<OrderItemEntity>) {
+        orderItemJpaRepository.saveAll(orderItemEntities)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.order
+
+import com.loopers.domain.order.OrderEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OrderJpaRepository: JpaRepository<OrderEntity, Long> {
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.order
+
+import com.loopers.domain.order.OrderEntity
+import com.loopers.domain.order.OrderRepository
+import org.springframework.stereotype.Component
+
+@Component
+class OrderRepositoryImpl(
+    private val orderJpaRepository: OrderJpaRepository
+): OrderRepository {
+
+    override fun save(order: OrderEntity): OrderEntity {
+        return orderJpaRepository.save(order)
+    }
+
+
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductHistoryJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductHistoryJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductHistoryEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductHistoryJpaRepository : JpaRepository<ProductHistoryEntity, Long>, ProductHistoryRepositoryCustom {
+
+    fun findByProductIdIn(productIds: List<Long>): List<ProductHistoryEntity>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductHistoryRepositoryCustom.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductHistoryRepositoryCustom.kt
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductHistoryEntity
+import com.loopers.domain.product.QProductHistoryEntity
+import com.loopers.support.querydsl.CmsQuerydslRepositorySupport
+import com.querydsl.core.group.GroupBy.groupBy
+
+interface ProductHistoryRepositoryCustom {
+
+    fun findProductIdToHistoryByProductIds(productIds: Collection<Long>): List<ProductHistoryEntity>
+}
+
+class ProductHistoryRepositoryCustomImpl : CmsQuerydslRepositorySupport(ProductHistoryEntity::class.java), ProductHistoryRepositoryCustom {
+
+    companion object {
+        private val productHistory = QProductHistoryEntity.productHistoryEntity
+    }
+
+    override fun findProductIdToHistoryByProductIds(productIds: Collection<Long>): List<ProductHistoryEntity> {
+
+        val productIdToLatestId: Map<Long, Long> = from(productHistory)
+            .where(productHistory.productId.`in`(productIds))
+            .groupBy(productHistory.productId)
+            .transform(
+                groupBy(productHistory.productId)
+                    .`as`(productHistory.id.max())
+            )
+
+        val latestHistories: List<ProductHistoryEntity> = from(productHistory)
+            .where(productHistory.id.`in`(productIdToLatestId.values))
+            .fetch()
+
+        return latestHistories
+    }
+
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductHistoryRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductHistoryRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductHistoryEntity
+import com.loopers.domain.product.ProductHistoryRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ProductHistoryRepositoryImpl(
+    private val productHistoryJpaRepository: ProductHistoryJpaRepository
+): ProductHistoryRepository {
+
+    override fun saveAll(productHistory: List<ProductHistoryEntity>): List<ProductHistoryEntity> {
+        return productHistoryJpaRepository.saveAll(productHistory)
+    }
+
+    override fun findProductIdToHistoryByProductIds(productIds: Collection<Long>): List<ProductHistoryEntity> {
+        return productHistoryJpaRepository.findProductIdToHistoryByProductIds(productIds)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductJpaRepository.kt
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductEntity
+import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface ProductJpaRepository : JpaRepository<ProductEntity, Long>, ProductRepositoryCustom {
+
+    @EntityGraph(attributePaths = ["brand"])
+    fun findWithBrandById(id: Long): ProductEntity?
+
+    fun findByIdIn(ids: Collection<Long>): List<ProductEntity>
+
+    @Modifying
+    @Query("UPDATE ProductEntity p SET p.likeCount = p.likeCount + 1 WHERE p.id = :productId")
+    fun incrementLikeCount(productId: Long): Int
+
+    @Modifying
+    @Query("UPDATE ProductEntity p SET p.likeCount = p.likeCount - 1 WHERE p.id = :productId")
+    fun decrementLikeCount(productId: Long): Int
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductLikeJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductLikeJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductLikeEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductLikeJpaRepository : JpaRepository<ProductLikeEntity, Long> {
+
+    fun findByUserIdAndProductId(userId: String, productId: Long): ProductLikeEntity?
+
+    fun findByUserId(userId: String): List<ProductLikeEntity>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductLikeRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductLikeRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductLikeEntity
+import com.loopers.domain.product.ProductLikeRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ProductLikeRepositoryImpl (
+    private val productLikeJpaRepository: ProductLikeJpaRepository
+): ProductLikeRepository {
+
+    override fun findByUserIdAndProductId(
+        userId: String,
+        productId: Long,
+    ): ProductLikeEntity? {
+        return productLikeJpaRepository.findByUserIdAndProductId(userId, productId)
+    }
+
+    override fun findByUserId(userId: String): List<ProductLikeEntity> {
+        return productLikeJpaRepository.findByUserId(userId)
+    }
+
+    override fun save(entity: ProductLikeEntity) {
+        productLikeJpaRepository.save(entity)
+    }
+
+    override fun delete(entity: ProductLikeEntity) {
+        productLikeJpaRepository.delete(entity)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductRepositoryCustom.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductRepositoryCustom.kt
@@ -1,0 +1,71 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.brand.QBrandEntity
+import com.loopers.domain.product.ProductCommand
+import com.loopers.domain.product.ProductEntity
+import com.loopers.domain.product.ProductListGetDto
+import com.loopers.domain.product.QProductEntity
+import com.loopers.support.querydsl.CmsQuerydslRepositorySupport
+import com.loopers.support.querydsl.eqNotNull
+import com.loopers.support.querydsl.inNotEmpty
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.Projections
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Sort
+import org.springframework.data.support.PageableExecutionUtils
+
+interface ProductRepositoryCustom {
+    fun findListByCriteria(command: ProductCommand.QueryCriteria): Page<ProductListGetDto>
+}
+
+class ProductRepositoryCustomImpl : CmsQuerydslRepositorySupport(ProductEntity::class.java), ProductRepositoryCustom {
+
+    companion object {
+        private val product = QProductEntity.productEntity
+        private val brand = QBrandEntity.brandEntity
+    }
+
+    override fun findListByCriteria(command: ProductCommand.QueryCriteria): Page<ProductListGetDto> {
+        val where = BooleanBuilder().apply {
+            and(product.brandId.inNotEmpty(command.brandIds))
+            and(product.id.eqNotNull(command.productId))
+        }
+
+        val from = from(product)
+            .innerJoin(brand).on(product.brandId.eq(brand.id))
+            .where(where)
+
+        val result = from
+            .orderBy(order(command.pageable.sort))
+            .offset(command.pageable.offset)
+            .select(
+                Projections.constructor(
+                    ProductListGetDto::class.java,
+                    product.id,
+                    product.name,
+                    product.brandId,
+                    brand.name,
+                    product.likeCount,
+                    product.price
+                )
+            ).fetch()
+
+        return PageableExecutionUtils.getPage(result, command.pageable, from::fetchCount)
+    }
+
+    private fun order(sort: Sort): OrderSpecifier<*> {
+        val first = sort.firstOrNull()
+        return if (first != null)
+            OrderSpecifier(
+                if (first.isAscending) Order.ASC else Order.DESC,
+                if (first.property == "latest") product.id
+                else if (first.property == "price") product.price
+                else if (first.property == "likes") product.likeCount
+                else null
+            )
+        else
+            OrderSpecifier(Order.DESC, product.id)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductRepositoryImpl.kt
@@ -1,0 +1,49 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductCommand
+import com.loopers.domain.product.ProductEntity
+import com.loopers.domain.product.ProductListGetDto
+import com.loopers.domain.product.ProductRepository
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.data.domain.Page
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRepositoryImpl (
+    private val productJpaRepository: ProductJpaRepository
+): ProductRepository {
+
+    override fun save(product: ProductEntity): ProductEntity {
+        return productJpaRepository.save(product)
+    }
+
+    override fun saveAll(product: List<ProductEntity>): List<ProductEntity> {
+        return productJpaRepository.saveAll(product)
+    }
+
+    override fun findById(productId: Long): ProductEntity {
+        return productJpaRepository.findById(productId)
+            .orElseThrow { CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다.") }
+    }
+
+    override fun findListByCriteria(command: ProductCommand.QueryCriteria): Page<ProductListGetDto> {
+        return productJpaRepository.findListByCriteria(command)
+    }
+
+    override fun findByIdIn(ids: Collection<Long>): List<ProductEntity> {
+        return productJpaRepository.findByIdIn(ids)
+    }
+
+    override fun getWithBrandById(id: Long): ProductEntity {
+        return productJpaRepository.findWithBrandById(id) ?: throw CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다.")
+    }
+
+    override fun incrementLikeCount(productId: Long): Int {
+        return productJpaRepository.incrementLikeCount(productId)
+    }
+
+    override fun decrementLikeCount(productId: Long) {
+        productJpaRepository.decrementLikeCount(productId)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/user/UserRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/user/UserRepositoryImpl.kt
@@ -9,8 +9,8 @@ class UserRepositoryImpl(
     private val userJpaRepository: UserJpaRepository
 ): UserRepository {
 
-    override fun save(user: UserEntity) {
-        userJpaRepository.save(user)
+    override fun save(user: UserEntity) : UserEntity {
+        return userJpaRepository.save(user)
     }
 
     override fun findByUserId(userId: String): UserEntity? {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/brand/BrandV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/brand/BrandV1ApiSpec.kt
@@ -1,0 +1,12 @@
+package com.loopers.interfaces.api.brand
+
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.interfaces.api.product.ProductV1Models
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PathVariable
+
+@Tag(name = "Brand V1 Api", description = "상품 조회")
+interface BrandV1ApiSpec {
+
+    fun get(@PathVariable brandId: Long): ApiResponse<BrandV1Models.Response.Info>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/brand/BrandV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/brand/BrandV1Controller.kt
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.brand
+
+import com.loopers.application.brand.BrandFacade
+import com.loopers.interfaces.api.ApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/brand")
+class BrandV1Controller(
+    private val brandFacade: BrandFacade
+) {
+    @GetMapping("/{brandId}")
+    fun get(@PathVariable brandId: Long): ApiResponse<BrandV1Models.Response.Info> {
+        return ApiResponse.success(brandFacade.get(brandId))
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/brand/BrandV1Models.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/brand/BrandV1Models.kt
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.brand
+
+import com.loopers.domain.brand.BrandGetDto
+
+class BrandV1Models {
+
+    class Response {
+
+        data class Info(
+            val id: Long,
+            val name: String,
+        ) {
+            companion object {
+                fun of(brand: BrandGetDto) = Info (
+                    id = brand.id,
+                    name = brand.name,
+                )
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1ApiSpec.kt
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.api.order
+
+import com.loopers.interfaces.api.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+
+@Tag(name = "Order V1 Api", description = "주문")
+interface OrderV1ApiSpec {
+
+    fun create(request: OrderV1Models.Request.Create, httpRequest: HttpServletRequest) : ApiResponse<Unit>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.order
+
+import com.loopers.application.order.OrderFacade
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/orders")
+class OrderV1Controller(
+    private val orderFacade: OrderFacade,
+): OrderV1ApiSpec {
+
+    @PostMapping
+    override fun create(@RequestBody @Valid request: OrderV1Models.Request.Create, httpRequest: HttpServletRequest) : ApiResponse<Unit> {
+        val userId = httpRequest.getHeader("X-USER-ID") ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID, "X-USER-ID is missing")
+        return ApiResponse.success(orderFacade.create(request.toCommand(userId)))
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
@@ -20,6 +20,6 @@ class OrderV1Controller(
     @PostMapping
     override fun create(@RequestBody @Valid request: OrderV1Models.Request.Create, httpRequest: HttpServletRequest) : ApiResponse<Unit> {
         val userId = httpRequest.getHeader("X-USER-ID") ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID, "X-USER-ID is missing")
-        return ApiResponse.success(orderFacade.create(request.toCommand(userId)))
+        return ApiResponse.success(orderFacade.create(request.toOrderCommand(userId), request.toPaymentCommand()))
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Models.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Models.kt
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.api.order
+
+import com.loopers.domain.order.OrderCommand
+import com.loopers.domain.type.PaymentType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+
+class OrderV1Models {
+
+    class Request {
+
+        data class Create(
+            @field:NotBlank
+            val items: List<Item>,
+            @field:NotNull
+            val paymentType: PaymentType
+        ) {
+            fun toCommand(userId: String): OrderCommand.Create {
+                return OrderCommand.Create(
+                    userId = userId,
+                    items = items.map { OrderCommand.Item.of(it) },
+                    paymentType = paymentType
+                )
+            }
+        }
+
+        data class Item(
+            val productId: Long,
+            val price: BigDecimal,
+            val qty: Int,
+        )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Models.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Models.kt
@@ -1,9 +1,9 @@
 package com.loopers.interfaces.api.order
 
 import com.loopers.domain.order.OrderCommand
+import com.loopers.domain.payment.PaymentCommand
 import com.loopers.domain.type.PaymentType
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import java.math.BigDecimal
 
 class OrderV1Models {
@@ -13,17 +13,27 @@ class OrderV1Models {
         data class Create(
             @field:NotBlank
             val items: List<Item>,
-            @field:NotNull
-            val paymentType: PaymentType
+            @field:NotBlank
+            val payments: List<Payment>
         ) {
-            fun toCommand(userId: String): OrderCommand.Create {
+            fun toOrderCommand(userId: String): OrderCommand.Create {
                 return OrderCommand.Create(
                     userId = userId,
                     items = items.map { OrderCommand.Item.of(it) },
-                    paymentType = paymentType
+                )
+            }
+
+            fun toPaymentCommand(): PaymentCommand.Create {
+                return PaymentCommand.Create(
+                    payments = payments.map { PaymentCommand.Payment.of(it) },
                 )
             }
         }
+
+        data class Payment(
+            val type: PaymentType,
+            val amount: BigDecimal,
+        )
 
         data class Item(
             val productId: Long,

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1ApiSpec.kt
@@ -9,10 +9,11 @@ import jakarta.validation.Valid
 @Tag(name = "Point V1 Api", description = "포인트 조회 및 충전")
 interface PointV1ApiSpec {
 
-    fun get(request: HttpServletRequest): ApiResponse<PointV1Dto.Response.PointResponse>
+    fun get(request: HttpServletRequest): ApiResponse<PointV1Models.Response.Get>
 
     fun charge(
-        @RequestBody @Valid request: PointV1Dto.Request.Charge, httpRequest: HttpServletRequest
-     ): ApiResponse<PointV1Dto.Response.ChargeResponse>
- }
+        @RequestBody @Valid request: PointV1Models.Request.Charge, httpRequest: HttpServletRequest
+     ): ApiResponse<PointV1Models.Response.Charge>
+
+}
 

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Controller.kt
@@ -19,13 +19,13 @@ class PointV1Controller(
 ) : PointV1ApiSpec {
 
     @GetMapping
-    override fun get(request: HttpServletRequest): ApiResponse<PointV1Dto.Response.PointResponse> {
+    override fun get(request: HttpServletRequest): ApiResponse<PointV1Models.Response.Get> {
         val userId = request.getHeader("X-USER-ID") ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID, "X-USER-ID is missing")
         return pointFacade.get(userId).let { ApiResponse.success(it) }
     }
 
     @PostMapping("/charge")
-    override fun charge(@RequestBody @Valid request: PointV1Dto.Request.Charge, httpRequest: HttpServletRequest): ApiResponse<PointV1Dto.Response.ChargeResponse> {
+    override fun charge(@RequestBody @Valid request: PointV1Models.Request.Charge, httpRequest: HttpServletRequest): ApiResponse<PointV1Models.Response.Charge> {
         val userId = httpRequest.getHeader("X-USER-ID") ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID, "X-USER-ID is missing")
         return pointFacade.charge(request.toCommand(userId)).let { ApiResponse.success(it) }
     }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Models.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Models.kt
@@ -2,14 +2,15 @@ package com.loopers.interfaces.api.point
 
 import com.loopers.domain.point.PointCommand
 import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
 
-class PointV1Dto {
+class PointV1Models {
 
     class Request {
 
         data class Charge(
             @field:NotNull
-            val amount: Long
+            val amount: BigDecimal
         ) {
             fun toCommand(userId: String) = PointCommand.ChargeInput(
                     userId = userId,
@@ -20,13 +21,13 @@ class PointV1Dto {
 
     class Response {
 
-        data class PointResponse(
+        data class Get(
             val userId: String,
-            val amount: Long,
+            val amount: BigDecimal,
         ) {
             companion object {
-                fun of(command: PointCommand.PointInfo): PointResponse {
-                    return PointResponse(
+                fun of(command: PointCommand.PointInfo): Get {
+                    return Get(
                         userId = command.userId,
                         amount = command.amount
                     )
@@ -34,12 +35,12 @@ class PointV1Dto {
             }
         }
 
-        data class ChargeResponse(
-            val amount: Long,
+        data class Charge(
+            val amount: BigDecimal,
         ) {
             companion object {
-                fun of(command: PointCommand.PointInfo): ChargeResponse {
-                    return ChargeResponse(
+                fun of(command: PointCommand.PointInfo): Charge {
+                    return Charge(
                         amount = command.amount
                     )
                 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1ApiController.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1ApiController.kt
@@ -1,0 +1,52 @@
+package com.loopers.interfaces.api.product
+
+import com.loopers.application.product.ProductFacade
+import com.loopers.domain.product.ProductCommand
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.servlet.http.HttpServletRequest
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/products")
+class ProductV1ApiController(
+    private val productFacade: ProductFacade
+): ProductV1ApiSpec {
+
+    @GetMapping("/{productId}")
+    override fun get(@PathVariable productId: Long) : ApiResponse<ProductV1Models.Response.GetInfo> {
+        return ApiResponse.success(productFacade.get(productId))
+    }
+
+    @GetMapping
+    override fun getList(@ParameterObject request: ProductV1Models.Request.GetList, @ParameterObject pageable: Pageable): ApiResponse<Page<ProductV1Models.Response.GetList>> {
+        return ApiResponse.success(productFacade.getList(request.toCommand(pageable)))
+    }
+
+    @GetMapping("/{productId}/likes")
+    override fun like(
+        request: HttpServletRequest,
+        @PathVariable productId: Long,
+    ): ApiResponse<Unit> {
+        val userId = request.getHeader("X-USER-ID") ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID, "X-USER-ID is missing")
+        return ApiResponse.success(productFacade.like(ProductCommand.Like(productId, userId)))
+    }
+
+    @DeleteMapping("/{productId}/likes")
+    override fun deleteLike(
+        request: HttpServletRequest,
+        @PathVariable productId: Long,
+    ): ApiResponse<Unit> {
+        val userId = request.getHeader("X-USER-ID") ?: throw CoreException(ErrorType.NOT_FOUND_USER_ID, "X-USER-ID is missing")
+        return ApiResponse.success(productFacade.deleteLike(ProductCommand.Like(productId, userId)))
+    }
+
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1ApiSpec.kt
@@ -1,0 +1,22 @@
+package com.loopers.interfaces.api.product
+
+import com.loopers.interfaces.api.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.web.bind.annotation.PathVariable
+
+@Tag(name = "Product V1 Api", description = "상품 조회")
+interface ProductV1ApiSpec {
+
+    fun get(@PathVariable productId: Long) : ApiResponse<ProductV1Models.Response.GetInfo>
+
+    fun getList(@ParameterObject request: ProductV1Models.Request.GetList, @ParameterObject pageable: Pageable): ApiResponse<Page<ProductV1Models.Response.GetList>>
+
+    fun like(request: HttpServletRequest, productId: Long): ApiResponse<Unit>
+
+    fun deleteLike(request: HttpServletRequest, productId: Long): ApiResponse<Unit>
+
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1Models.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1Models.kt
@@ -1,0 +1,75 @@
+package com.loopers.interfaces.api.product
+
+import com.loopers.domain.product.ProductCommand
+import com.loopers.domain.product.ProductWithBrandDto
+import com.loopers.domain.product.ProductListGetDto
+import org.springframework.data.domain.Pageable
+import java.math.BigDecimal
+
+
+class ProductV1Models {
+
+    class Request {
+
+        data class GetList(
+            val brandIds: List<Long>,
+            val productId: Long?
+        ) {
+            fun toCommand(pageable: Pageable) = ProductCommand.QueryCriteria (
+                brandIds = brandIds,
+                productId = productId,
+                pageable = pageable
+            )
+        }
+
+    }
+
+    class Response {
+
+        data class GetInfo(
+            val productId: Long,
+            val productName: String,
+            val brandId: Long,
+            val brandName: String,
+            val likeCount: Int,
+            val stock: Int,
+            val price: BigDecimal
+        ) {
+            companion object {
+                fun of(dto: ProductWithBrandDto): GetInfo {
+                    return GetInfo(
+                        productId = dto.productId,
+                        productName = dto.productName,
+                        brandId = dto.brandId,
+                        brandName = dto.brandName,
+                        likeCount = dto.likeCount,
+                        stock = dto.stock,
+                        price = dto.price
+                    )
+                }
+            }
+        }
+
+        data class GetList(
+            val productId: Long,
+            val productName: String,
+            val brandId: Long,
+            val brandName: String,
+            val likeCount: Int,
+            val price: BigDecimal
+        ) {
+            companion object {
+                fun of(dto: ProductListGetDto): GetList {
+                    return GetList(
+                        dto.productId,
+                        dto.productName,
+                        dto.brandId,
+                        dto.brandName,
+                        dto.likeCount,
+                        dto.price
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1ApiSpec.kt
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RequestBody
 @Tag(name = "User V1 Api", description = "회원가입 및 내정보 조회")
 interface UserV1ApiSpec {
     @Schema(description = "회원 가입")
-    fun create(@RequestBody @Valid request: UserV1Dto.Request.SignUp): ApiResponse<UserV1Dto.Response.UserResponse>
+    fun create(@RequestBody @Valid request: UserV1Models.Request.SignUp): ApiResponse<UserV1Models.Response.Info>
 
     @Schema(description = "내 정보 조회")
-    fun getMyInfo(request: HttpServletRequest): ApiResponse<UserV1Dto.Response.UserResponse>
+    fun getMyInfo(request: HttpServletRequest): ApiResponse<UserV1Models.Response.Info>
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Controller.kt
@@ -17,7 +17,7 @@ class UserV1Controller(
 ): UserV1ApiSpec {
 
     @PostMapping
-    override fun create(@RequestBody @Valid request: UserV1Dto.Request.SignUp): ApiResponse<UserV1Dto.Response.UserResponse> {
+    override fun create(@RequestBody @Valid request: UserV1Models.Request.SignUp): ApiResponse<UserV1Models.Response.Info> {
         return userFacade.signUp(request.toCommand())
             .let { ApiResponse.success(it) }
     }
@@ -25,7 +25,7 @@ class UserV1Controller(
     @GetMapping("/me")
     override fun getMyInfo(
         request: HttpServletRequest
-    ): ApiResponse<UserV1Dto.Response.UserResponse> {
+    ): ApiResponse<UserV1Models.Response.Info> {
         val userId = request.getHeader("X-USER-ID") ?: throw IllegalStateException("X-USER-ID not set")
         return userFacade.getMyInfo(userId)
             .let { ApiResponse.success(it) }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Models.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Models.kt
@@ -5,7 +5,7 @@ import com.loopers.domain.user.UserCommand
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
-class UserV1Dto {
+class UserV1Models {
 
     class Request {
 
@@ -33,15 +33,15 @@ class UserV1Dto {
 
     class Response {
 
-        data class UserResponse(
+        data class Info(
             val userId: String,
             val birthDate: String,
             val email: String,
             val gender: Gender
         ) {
             companion object {
-                fun of(command: UserCommand.UserInfo): UserResponse {
-                    return UserResponse(
+                fun of(command: UserCommand.UserInfo): Info {
+                    return Info(
                         userId = command.userId,
                         birthDate = command.birth,
                         email = command.email,

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -31,10 +31,39 @@ enum class ErrorType(val status: HttpStatus, val code: String, val message: Stri
         "해당 회원이 존재하지 않습니다."
     ),
 
+    /**Product**/
+    PRODUCT_NOT_FOUND(
+        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase,
+        "존재하지 않는 상품입니다"
+    ),
+
     /**Charge**/
     CHARGE_AMOUNT_MUST_BE_POSITIVE(
         HttpStatus.BAD_REQUEST,
         HttpStatus.BAD_REQUEST.reasonPhrase,
         "0 이하의 정수로 포인트를 충전할 수 없습니다."
-    )
+    ),
+    NOT_ENOUGH_POINTS(
+        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase,
+        "포인트가 부족합니다."
+    ),
+
+
+    /**Stock**/
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase, "재고 부족"),
+
+    /**Order**/
+    QTY_MUST_BE_POSITIVE(
+        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase,
+        "0 이하의 정수인 QTY는 허용이 안됩니다."
+    ),
+    PRICE_MUST_BE_POSITIVE(
+        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase,
+        "0 이하의 정수인 가격은 허용이 안됩니다."
+    ),
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -49,6 +49,16 @@ enum class ErrorType(val status: HttpStatus, val code: String, val message: Stri
         HttpStatus.BAD_REQUEST.reasonPhrase,
         "포인트가 부족합니다."
     ),
+    INVALID_PAYMENT_TYPE(
+        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase,
+        "지원하지 않는 결제 수단입니다"
+    ),
+    INVALID_PAYMENT_PRICE(
+        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST.reasonPhrase,
+        "잘못된 결제금액입니다."
+    ),
 
 
     /**Stock**/

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/CmsQuerydslRepositorySupport.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/CmsQuerydslRepositorySupport.kt
@@ -1,0 +1,13 @@
+package com.loopers.support.querydsl
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+
+abstract class CmsQuerydslRepositorySupport(domainClass: Class<*>?) :
+    DefaultQuerydslRepositorySupport(domainClass)
+{
+    @PersistenceContext(unitName = "entityManagerFactory")
+    override fun setEntityManager(entityManager: EntityManager) {
+        super.setEntityManager(entityManager)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/DefaultQuerydslRepositorySupport.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/DefaultQuerydslRepositorySupport.kt
@@ -1,0 +1,49 @@
+package com.loopers.support.querydsl
+
+import com.querydsl.core.types.EntityPath
+import com.querydsl.jpa.JPQLQuery
+import com.querydsl.jpa.impl.AbstractJPAQuery
+import com.querydsl.jpa.impl.JPAQuery
+import com.querydsl.core.types.dsl.PathBuilder
+import com.querydsl.jpa.JPQLTemplates
+import jakarta.persistence.EntityManager
+import org.springframework.data.jpa.repository.support.Querydsl
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+
+abstract class DefaultQuerydslRepositorySupport(domainClass: Class<*>?): QuerydslRepositorySupport(domainClass!!) {
+    private var querydsl: DefaultQuerydsl? = null
+
+    override fun getQuerydsl(): Querydsl? {
+        if (querydsl == null && entityManager != null) {
+            querydsl = DefaultQuerydsl(entityManager!!, getBuilder<Any>())
+        }
+        return querydsl
+    }
+
+    override fun from(vararg paths: EntityPath<*>): JPQLQuery<Any> {
+        return requiredQuerydsl!!.createQuery(*paths)
+    }
+
+    override fun <T> from(path: EntityPath<T>): JPQLQuery<T> {
+        return requiredQuerydsl!!.createQuery(path).select(path)
+    }
+
+    private val requiredQuerydsl: Querydsl?
+        get() {
+            checkNotNull(getQuerydsl()) { "Querydsl is null" }
+
+            return querydsl
+        }
+
+
+    class DefaultQuerydsl(
+        private val entityManager: EntityManager,
+        builder: PathBuilder<*>
+    ) : Querydsl(entityManager, builder) {
+
+        override fun <T> createQuery(): AbstractJPAQuery<T, JPAQuery<T>> {
+            // https://github.com/querydsl/querydsl/issues/3428
+            return JPAQuery(entityManager, JPQLTemplates.DEFAULT)
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/ExpressionExtension.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/ExpressionExtension.kt
@@ -1,0 +1,52 @@
+package com.loopers.support.querydsl
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.ComparableExpression
+import com.querydsl.core.types.dsl.NumberExpression
+import com.querydsl.core.types.dsl.SimpleExpression
+import com.querydsl.core.types.dsl.StringExpression
+
+fun <T> SimpleExpression<T>.eqNotNull(right: T?): BooleanExpression? {
+    if (right == null) return null
+    return eq(right)
+}
+
+fun <T, S : T> SimpleExpression<T>.inNotNull(right: Collection<S>?): BooleanExpression? {
+    if (right == null) return null
+    return `in`(right)
+}
+
+fun <T, S : T> SimpleExpression<T>.inNotEmpty(right: Collection<S>?): BooleanExpression? {
+    if (right.isNullOrEmpty()) return null
+    return `in`(right)
+}
+
+fun <T, S : T> SimpleExpression<T>.notInNotNull(right: Collection<S>?): BooleanExpression? {
+    if (right == null) return null
+    return notIn(right)
+}
+
+fun <T : Comparable<*>> ComparableExpression<T>.loeNotNull(right: T?): BooleanExpression? {
+    if (right == null) return null
+    return loe(right)
+}
+
+fun <T : Comparable<*>> ComparableExpression<T>.gtNotNull(right: T?): BooleanExpression? {
+    if (right == null) return null
+    return gt(right)
+}
+
+fun StringExpression.containsNotNull(right: String?): BooleanExpression? {
+    if (right == null) return null
+    return contains(right)
+}
+
+fun <T> NumberExpression<T>.loeNotNull(right: T?): BooleanExpression? where T : Number, T : Comparable<*> {
+    if (right == null) return null
+    return loe(right)
+}
+
+fun StringExpression.startsWithNotNull(right: String?): BooleanExpression? {
+    if (right == null) return null
+    return startsWith(right)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/QueryDslConditionUilts.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/querydsl/QueryDslConditionUilts.kt
@@ -1,0 +1,49 @@
+package com.loopers.support.querydsl
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.ComparableExpression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.SimpleExpression
+import com.querydsl.core.types.dsl.StringExpression
+
+fun <T> eq(expression: SimpleExpression<T>, value: T?): BooleanExpression? =
+    value?.let { expression.eq(it) }
+
+fun <T> ne(expression: SimpleExpression<T>, value: T?): BooleanExpression? =
+    value?.let { expression.ne(it) }
+
+fun like(expression: StringExpression, value: String?): BooleanExpression? =
+    value?.let { expression.startsWith(it) }
+
+fun contains(expression: StringExpression, value: String?): BooleanExpression? =
+    value?.let { expression.contains(it) }
+
+fun <T> `in`(expression: SimpleExpression<T>, values: Collection<T?>?): BooleanExpression? =
+    if (!values.isNullOrEmpty())
+        expression.`in`(values)
+    else
+        null
+
+fun <T> notIn(expression: SimpleExpression<T>, values: Collection<T?>?): BooleanExpression? =
+    if (!values.isNullOrEmpty())
+        expression.notIn(values)
+    else
+        null
+
+fun <T : Comparable<T>> loe(expression: ComparableExpression<T>, value: T?): BooleanExpression? =
+    value?.let { expression.loe(it) }
+
+fun <T : Comparable<T>> lt(expression: ComparableExpression<T>, value: T?): BooleanExpression? =
+    value?.let { expression.lt(it) }
+
+fun <T : Comparable<T>> goe(expression: ComparableExpression<T>, value: T?): BooleanExpression? =
+    value?.let { expression.goe(it) }
+
+fun <T : Comparable<T>> gt(expression: ComparableExpression<T>, value: T?): BooleanExpression? =
+    value?.let { expression.gt(it) }
+
+fun <T> inOrFalse(expression: SimpleExpression<T>, values: Collection<T?>?): BooleanExpression =
+    if (!values.isNullOrEmpty())
+        expression.`in`(values)
+    else
+        Expressions.FALSE

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/order/OrderFacadeTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/order/OrderFacadeTest.kt
@@ -1,0 +1,85 @@
+package com.loopers.application.order
+
+
+import com.loopers.domain.order.OrderCommand
+import com.loopers.domain.order.OrderItemDto
+import com.loopers.domain.order.OrderItemService
+import com.loopers.domain.order.OrderService
+import com.loopers.domain.order.StockService
+import com.loopers.domain.payment.PaymentService
+import com.loopers.domain.product.ProductHistoryDto
+import com.loopers.domain.product.ProductHistoryService
+import com.loopers.domain.type.OrderItemStatus
+import org.mockito.kotlin.whenever
+
+import com.loopers.domain.type.PaymentType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.verify
+import java.math.BigDecimal
+
+@ExtendWith(MockitoExtension::class)
+class OrderFacadeTest {
+
+    @Mock
+    private lateinit var productHistoryService: ProductHistoryService
+    @Mock
+    private lateinit var orderService: OrderService
+    @Mock
+    private lateinit var orderItemService: OrderItemService
+    @Mock
+    private lateinit var paymentService: PaymentService
+    @Mock
+    private lateinit var stockService: StockService
+
+    @InjectMocks
+    private lateinit var orderFacade: OrderFacade
+
+    @Test
+    fun `create should process order successfully`() {
+        // given
+        val userId = "user-123"
+        val items = listOf(
+            OrderCommand.Item(productId = 1L, price = BigDecimal(1000), qty = 2),
+            OrderCommand.Item(productId = 2L, price = BigDecimal(2000), qty = 1),
+        )
+        val paymentType = PaymentType.POINT
+        val command = OrderCommand.Create(userId = userId, items = items, paymentType = paymentType)
+
+        val productHistoryDtos = listOf(
+            ProductHistoryDto(
+                productId = 1L, productHistoryId = 101L, productName = "Product 1", brandId = 10L, stock = 100, likeCount = 5
+            ),
+            ProductHistoryDto(
+                productId = 2L, productHistoryId = 102L, productName = "Product 2", brandId = 10L, stock = 50, likeCount = 3
+            ),
+        )
+        val orderId = 555L
+        val orderItemDtos = listOf(
+            OrderItemDto(1L, orderId, 101L, BigDecimal(1000), BigDecimal(2000), 2, OrderItemStatus.ORDERED),
+            OrderItemDto(2L, orderId, 102L, BigDecimal(2000), BigDecimal(2000), 1, OrderItemStatus.ORDERED),
+        )
+
+        // stubbing
+        whenever(productHistoryService.getProductsForOrder(listOf(1L, 2L))).thenReturn(productHistoryDtos)
+        whenever(orderService.create(command)).thenReturn(orderId)
+        whenever(orderItemService.create(items, orderId, productHistoryDtos)).thenReturn(orderItemDtos)
+        doNothing().whenever(paymentService).charge(userId, paymentType, orderItemDtos)
+        doNothing().whenever(stockService).changeStock(command, listOf(1L, 2L))
+
+        // when
+        orderFacade.create(command)
+
+        // then
+        verify(productHistoryService).getProductsForOrder(listOf(1L, 2L))
+        verify(orderService).create(command)
+        verify(orderItemService).create(items, orderId, productHistoryDtos)
+        verify(paymentService).charge(userId, paymentType, orderItemDtos)
+        verify(stockService).changeStock(command, listOf(1L, 2L))
+    }
+}
+

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/order/OrderFacadeTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/order/OrderFacadeTest.kt
@@ -13,6 +13,7 @@ import com.loopers.domain.type.OrderItemStatus
 import org.mockito.kotlin.whenever
 
 import com.loopers.domain.type.PaymentType
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -39,8 +40,9 @@ class OrderFacadeTest {
     @InjectMocks
     private lateinit var orderFacade: OrderFacade
 
+    @DisplayName("주문 생성 성공 테스트")
     @Test
-    fun `create should process order successfully`() {
+    fun `success_order`() {
         // given
         val userId = "user-123"
         val items = listOf(

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeTest.kt
@@ -101,7 +101,7 @@ class ProductFacadeTest(
             )
         }
 
-        @DisplayName("상품 좋아요 취소에 성공하면 상품 좋아요 이력이 삭제된다.")
+        @DisplayName("상품 좋아요 취소에 성공하면 상품 좋아요가 삭제된다.")
         @Test
         fun success_deleteLike() {
             // arrange

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeTest.kt
@@ -1,0 +1,267 @@
+package com.loopers.application.product
+
+import com.loopers.application.point.PointFacade
+import com.loopers.domain.brand.BrandEntity
+import com.loopers.domain.brand.BrandRepository
+import com.loopers.domain.point.PointRepository
+import com.loopers.domain.product.ProductCommand
+import com.loopers.domain.product.ProductLikeRepository
+import com.loopers.domain.product.ProductLikeService
+import com.loopers.domain.product.ProductRepository
+import com.loopers.domain.product.ProductService
+import com.loopers.domain.product.ProductWithBrandDto
+import com.loopers.domain.user.UserRepository
+import com.loopers.fixture.product.ProductFixture
+import com.loopers.fixture.user.UserFixture
+import com.loopers.support.IntegrationTestSupport
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertAll
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import java.math.BigDecimal
+import kotlin.test.Test
+
+class ProductFacadeTest(
+    private val productFacade: ProductFacade,
+    private val productRepository: ProductRepository,
+    private val userRepository: UserRepository,
+    private val brandRepository: BrandRepository,
+): IntegrationTestSupport() {
+
+    @Autowired
+    private lateinit var productLikeService: ProductLikeService
+
+    @DisplayName("좋아요")
+    @Nested
+    inner class LIKE {
+
+        @DisplayName("상품 좋아요 등록에 성공하면 상품 좋아요 수가 증가한다.")
+        @Test
+        fun success_like() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity = ProductFixture.Normal.create(brand.id)
+            val userEntity = UserFixture.Normal.createUserEntity()
+            val createdUser = userRepository.save(userEntity)
+            val createdProduct = productRepository.save(productEntity)
+            val likeCommand = ProductCommand.Like(createdProduct.id, createdUser.userId)
+
+            // act
+            productFacade.like(likeCommand)
+
+            // assert
+            val productLikes = productLikeService.getMyLikes(createdUser.userId)
+
+            // 데이터베이스에서 최신 상태를 직접 조회하여 검증
+            val updatedProduct = productRepository.findById(createdProduct.id)
+
+            assertAll(
+                { assertThat(productLikes).hasSize(1) },
+                { assertThat(productLikes[0].userId).isEqualTo(createdUser.userId) },
+                { assertThat(productLikes[0].productId).isEqualTo(createdProduct.id) },
+                { assertThat(updatedProduct.likeCount).isEqualTo(1) },
+            )
+        }
+
+        @DisplayName("상품 좋아요 여러번 할 경우 상태는 한번만 등록한것과 동일하다.")
+        @Test
+        fun duplicate_likeProduct() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity = ProductFixture.Normal.create(brand.id)
+            val userEntity = UserFixture.Normal.createUserEntity()
+            val createdUser = userRepository.save(userEntity)
+            val createdProduct = productRepository.save(productEntity)
+            val likeCommand = ProductCommand.Like(createdProduct.id, createdUser.userId)
+
+            // act
+            productFacade.like(likeCommand)
+            productFacade.like(likeCommand)
+            productFacade.like(likeCommand)
+
+            // assert
+            val productLikes = productLikeService.getMyLikes(createdUser.userId)
+
+            // 데이터베이스에서 최신 상태를 직접 조회하여 검증
+            val updatedProduct = productRepository.findById(createdProduct.id)
+
+            assertAll(
+                { assertThat(productLikes).hasSize(1) },
+                { assertThat(productLikes[0].userId).isEqualTo(createdUser.userId) },
+                { assertThat(productLikes[0].productId).isEqualTo(createdProduct.id) },
+                { assertThat(updatedProduct.likeCount).isEqualTo(1) },
+            )
+        }
+
+        @DisplayName("상품 좋아요 취소에 성공하면 상품 좋아요 이력이 삭제된다.")
+        @Test
+        fun success_deleteLike() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity = ProductFixture.Normal.create(brand.id)
+            val userEntity = UserFixture.Normal.createUserEntity()
+            val createdUser = userRepository.save(userEntity)
+            val createdProduct = productRepository.save(productEntity)
+            val likeCommand = ProductCommand.Like(createdProduct.id, createdUser.userId)
+
+            // act
+            productFacade.like(likeCommand)
+            productFacade.deleteLike(likeCommand)
+
+            // assert
+            val productLikes = productLikeService.getMyLikes(createdUser.userId)
+            val updatedProduct = productRepository.findById(createdProduct.id)
+
+            assertAll(
+                { assertThat(productLikes).hasSize(0) },
+                { assertThat(updatedProduct.likeCount).isEqualTo(0) },
+            )
+        }
+    }
+
+    @DisplayName("상품")
+    @Nested
+    inner class Product {
+
+        @DisplayName("상품 정보는 브랜드 정보, 좋아요수, 재고, 가격 등을 포함한다")
+        @Test
+        fun return_product_info () {
+            // given
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity = ProductFixture.Normal.create(brand.id)
+            val createdProduct = productRepository.save(productEntity)
+
+            // when
+            val result = productFacade.get(createdProduct.id)
+
+            // then
+            assertThat(result.productId).isEqualTo(createdProduct.id)
+            assertThat(result.productName).isEqualTo(createdProduct.name)
+            assertThat(result.likeCount).isEqualTo(createdProduct.likeCount)
+            assertThat(result.brandId).isEqualTo(createdProduct.brandId)
+            assertThat(result.brandName).isEqualTo("test brand")
+            assertThat(result.stock).isEqualTo(createdProduct.stock)
+            assertThat(result.price.compareTo(createdProduct.price)).isZero()
+        }
+
+        @DisplayName("상품 목록은 브랜드 정보, 좋아요수, 재고, 가격 등을 포함한다")
+        @Test
+        fun returnsProductList() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity1 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(300))
+            val productEntity2 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(200))
+            val productEntity3 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(100))
+            productRepository.saveAll(listOf(productEntity1, productEntity2, productEntity3))
+
+            // act
+            val pageRequest = PageRequest.of(0, 10, Sort.by("price").ascending())
+            val command = ProductCommand.QueryCriteria(
+                emptyList(), null, pageRequest)
+            val productsPage = productFacade.getList(command)
+
+            // assert
+            assertAll(
+                { Assertions.assertThat(productsPage).hasSize(3) },
+                { Assertions.assertThat(productsPage.totalElements).isEqualTo(3) },
+                { Assertions.assertThat(productsPage.content[0].price.compareTo(productEntity3.price)).isZero() },
+                { Assertions.assertThat(productsPage.content[0].brandId).isEqualTo(productEntity3.brandId) },
+                { Assertions.assertThat(productsPage.content[0].likeCount).isEqualTo(productEntity3.likeCount) },
+                { Assertions.assertThat(productsPage.content[0].brandName).isEqualTo("test brand") }
+            )
+        }
+
+        @DisplayName("상품 목록은 가격 오름차순으로 정렬할 수 있다.")
+        @Test
+        fun returnsProductsSortedByPriceAsc() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity1 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(300))
+            val productEntity2 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(200))
+            val productEntity3 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(100))
+            productRepository.saveAll(listOf(productEntity1, productEntity2, productEntity3))
+
+            // act
+            val pageRequest = PageRequest.of(0, 10, Sort.by("price").ascending())
+            val command = ProductCommand.QueryCriteria(
+                emptyList(), null, pageRequest)
+            val productsPage = productFacade.getList(command)
+
+            // assert
+            assertAll(
+                { Assertions.assertThat(productsPage).hasSize(3) },
+                { Assertions.assertThat(productsPage.totalElements).isEqualTo(3) },
+                { Assertions.assertThat(productsPage.content[0].price.compareTo(productEntity3.price)).isZero() },
+                { Assertions.assertThat(productsPage.content[1].price.compareTo(productEntity2.price)).isZero() },
+                { Assertions.assertThat(productsPage.content[2].price.compareTo(productEntity1.price)).isZero() },
+            )
+        }
+
+        @DisplayName("상품 목록은 최신순으로 정렬할 수 있다.")
+        @Test
+        fun returnsProductsSortedBylatest() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity1 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(300))
+            val productEntity2 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(200))
+            val productEntity3 = ProductFixture.Normal.createByPrice(brand.id, BigDecimal.valueOf(100))
+            val created = productRepository.saveAll(listOf(productEntity1, productEntity2, productEntity3)).sortedByDescending { it.id }
+
+            // act
+            val pageRequest = PageRequest.of(0, 10, Sort.by("latest").descending())
+            val command = ProductCommand.QueryCriteria(
+                emptyList(), null, pageRequest)
+            val productsPage = productFacade.getList(command)
+
+            // assert
+            assertAll(
+                { Assertions.assertThat(productsPage).hasSize(3) },
+                { Assertions.assertThat(productsPage.totalElements).isEqualTo(3) },
+                { Assertions.assertThat(productsPage.content[0].productId).isEqualTo(created[0].id) },
+                { Assertions.assertThat(productsPage.content[1].productId).isEqualTo(created[1].id) },
+                { Assertions.assertThat(productsPage.content[2].productId).isEqualTo(created[2].id) },
+            )
+        }
+
+        @DisplayName("상품 목록은 좋아요 내림차순으로 정렬할 수 있다.")
+        @Test
+        fun returnsProductsSortedByLikeDescending() {
+            // arrange
+            val brandTest = BrandEntity(name = "test brand")
+            val brand = brandRepository.save(brandTest)
+            val productEntity1 = ProductFixture.Normal.createByLikeCount(brand.id, 3)
+            val productEntity2 = ProductFixture.Normal.createByLikeCount(brand.id, 2)
+            val productEntity3 = ProductFixture.Normal.createByLikeCount(brand.id, 1)
+            productRepository.saveAll(listOf(productEntity1, productEntity2, productEntity3))
+
+            // act
+            val pageRequest = PageRequest.of(0, 10, Sort.by("likes").descending())
+            val command = ProductCommand.QueryCriteria(
+                emptyList(), null, pageRequest)
+            val productsPage = productFacade.getList(command)
+
+            // assert
+            assertAll(
+                { Assertions.assertThat(productsPage).hasSize(3) },
+                { Assertions.assertThat(productsPage.totalElements).isEqualTo(3) },
+                { Assertions.assertThat(productsPage.content[0].likeCount).isEqualTo(productEntity1.likeCount) },
+                { Assertions.assertThat(productsPage.content[1].likeCount).isEqualTo(productEntity2.likeCount) },
+                { Assertions.assertThat(productsPage.content[2].likeCount).isEqualTo(productEntity3.likeCount) },
+            )
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderModelTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderModelTest.kt
@@ -16,7 +16,7 @@ class OrderModelTest {
     @Nested
     inner class Order {
 
-        @DisplayName("0 이하의 정수로 qty로 들어올 경우 실패하여 CoreException가 발생한다.")
+        @DisplayName("0 이하의 정수로 qty로 들어올 경우 실패하여 CoreException이 발생한다.")
         @Test
         fun return_fail_when_qty_negative() {
             val userId = "testId"
@@ -29,7 +29,7 @@ class OrderModelTest {
             assertThat(result.errorType).isEqualTo(ErrorType.QTY_MUST_BE_POSITIVE)
         }
 
-        @DisplayName("0 이하의 정수로 price로 들어올 경우 실패하여 CoreExceptio가 발생한다.")
+        @DisplayName("0 이하의 정수로 price로 들어올 경우 실패하여 CoreException이 발생한다.")
         @Test
         fun return_fail_when_price_negative() {
             val userId = "testId"

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderModelTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderModelTest.kt
@@ -1,0 +1,45 @@
+package com.loopers.domain.order
+
+import com.loopers.fixture.order.OrderFixture
+import com.loopers.interfaces.api.order.OrderV1Models
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class OrderModelTest {
+
+    @DisplayName("주문")
+    @Nested
+    inner class Order {
+
+        @DisplayName("0 이하의 정수로 qty로 들어올 경우 실패하여 CoreException가 발생한다.")
+        @Test
+        fun return_fail_when_qty_negative() {
+            val userId = "testId"
+            val request = OrderFixture.InvalidQty.create()
+
+            val result = assertThrows<CoreException> {
+                request.toCommand(userId)
+            }
+
+            assertThat(result.errorType).isEqualTo(ErrorType.QTY_MUST_BE_POSITIVE)
+        }
+
+        @DisplayName("0 이하의 정수로 price로 들어올 경우 실패하여 CoreExceptio가 발생한다.")
+        @Test
+        fun return_fail_when_price_negative() {
+            val userId = "testId"
+            val request = OrderFixture.InvalidPrice.create()
+
+            val result = assertThrows<CoreException> {
+                request.toCommand(userId)
+            }
+
+            assertThat(result.errorType).isEqualTo(ErrorType.PRICE_MUST_BE_POSITIVE)
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderModelTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderModelTest.kt
@@ -1,7 +1,6 @@
 package com.loopers.domain.order
 
 import com.loopers.fixture.order.OrderFixture
-import com.loopers.interfaces.api.order.OrderV1Models
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +22,7 @@ class OrderModelTest {
             val request = OrderFixture.InvalidQty.create()
 
             val result = assertThrows<CoreException> {
-                request.toCommand(userId)
+                request.toOrderCommand(userId)
             }
 
             assertThat(result.errorType).isEqualTo(ErrorType.QTY_MUST_BE_POSITIVE)
@@ -36,7 +35,7 @@ class OrderModelTest {
             val request = OrderFixture.InvalidPrice.create()
 
             val result = assertThrows<CoreException> {
-                request.toCommand(userId)
+                request.toOrderCommand(userId)
             }
 
             assertThat(result.errorType).isEqualTo(ErrorType.PRICE_MUST_BE_POSITIVE)

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/PaymentServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/PaymentServiceTest.kt
@@ -70,7 +70,7 @@ class PaymentServiceTest {
         verify(paymentService, times(1)).charge(userId, paymentType, orderItems)
     }
 
-    @DisplayName("포인트 부족시 예외가 발생한다.")
+    @DisplayName("포인트 부족시 예외가 발생한다.(NOT_ENOUGH_POINTS)")
     @Test
     fun return_fail_when_point_not_enough() {
 

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/PaymentServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/PaymentServiceTest.kt
@@ -1,0 +1,106 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.payment.PaymentService
+import com.loopers.domain.payment.PointCharger
+import com.loopers.domain.point.PointEntity
+import com.loopers.domain.point.PointRepository
+import com.loopers.domain.type.OrderItemStatus
+import com.loopers.domain.type.PaymentType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.doNothing
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import java.math.BigDecimal
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class PaymentServiceTest {
+
+    @Mock
+    private lateinit var paymentService: PaymentService
+
+    @Mock
+    private lateinit var pointRepository: PointRepository
+
+    @InjectMocks
+    private lateinit var pointCharger: PointCharger
+
+    @DisplayName("결제 서비스 정상 호출")
+    @Test
+    fun `success_payment`() {
+        // given
+        val userId = "user-123"
+        val paymentType = PaymentType.POINT
+        val orderItems = listOf(
+            OrderItemDto(
+                id = 1L,
+                orderId = 100L,
+                productHistoryId = 200L,
+                unitPrice = BigDecimal("1000.00"),
+                totalPrice = BigDecimal("2000.00"),
+                qty = 2,
+                status = OrderItemStatus.ORDERED
+            ),
+            OrderItemDto(
+                id = 2L,
+                orderId = 100L,
+                productHistoryId = 201L,
+                unitPrice = BigDecimal("1500.00"),
+                totalPrice = BigDecimal("1500.00"),
+                qty = 1,
+                status = OrderItemStatus.ORDERED
+            )
+        )
+
+        // stub
+        doNothing().`when`(paymentService).charge(userId, paymentType, orderItems)
+
+        // when
+        paymentService.charge(userId, paymentType, orderItems)
+
+        // then
+        verify(paymentService, times(1)).charge(userId, paymentType, orderItems)
+    }
+
+    @DisplayName("포인트 부족시 예외가 발생한다.")
+    @Test
+    fun return_fail_when_point_not_enough() {
+
+        // given
+        val userId = "user-123"
+        val point = PointEntity(amount = BigDecimal("1000"), userId = userId)
+        val totalPrice = BigDecimal("2000")
+
+        // when & then
+        val exception = assertThrows<CoreException> {
+            pointCharger.validatePoint(point.amount, totalPrice)
+        }
+
+        assertThat(exception.errorType).isEqualTo(ErrorType.NOT_ENOUGH_POINTS)
+        assertThat(exception.message).contains("포인트가 부족합니다")
+    }
+
+    @DisplayName("포인트 차감 후 저장된다")
+    @Test
+    fun charge_points_and_save() {
+        // given
+        val userId = "user-123"
+        val point = PointEntity(amount = BigDecimal("5000"), userId = userId)
+        val totalPrice = BigDecimal("2000")
+
+        // when
+        pointCharger.updatePoint(point, totalPrice)
+
+        // then
+        assertThat(point.amount).isEqualTo(BigDecimal("3000"))
+        verify(pointRepository).save(point)
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/StockServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/StockServiceTest.kt
@@ -1,6 +1,8 @@
 package com.loopers.domain.order
 
 import com.loopers.domain.product.ProductEntity
+import com.loopers.domain.product.ProductHistoryRepository
+import com.loopers.domain.product.ProductRepository
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
 import org.assertj.core.api.Assertions.assertThat
@@ -8,12 +10,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import java.math.BigDecimal
 import kotlin.test.Test
 
 @ExtendWith(MockitoExtension::class)
 class StockServiceTest {
+
+    @Mock
+    lateinit var productRepository: ProductRepository
+
+    @Mock
+    lateinit var productHistoryRepository: ProductHistoryRepository
 
     @InjectMocks
     lateinit var stockService: StockService

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/StockServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/StockServiceTest.kt
@@ -1,0 +1,50 @@
+package com.loopers.domain.order
+
+import com.loopers.domain.product.ProductEntity
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.junit.jupiter.MockitoExtension
+import java.math.BigDecimal
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class StockServiceTest {
+
+    @InjectMocks
+    lateinit var stockService: StockService
+
+    @Test
+    @DisplayName("재고가 충분하면 정상적으로 차감된다")
+    fun `update_stock`() {
+        // given
+        val product = ProductEntity(
+            name = "상품",
+            brandId = 1L,
+            price = BigDecimal(1000),
+            stock = 10,
+            likeCount = 0
+        )
+
+        // when
+        stockService.updateStock(product, 3)
+
+        // then
+        assertThat(product.stock).isEqualTo(7)
+    }
+
+    @Test
+    @DisplayName("재고가 부족하면 CoreException이 발생한다")
+    fun `validateStock throws exception when stock is insufficient`() {
+
+        val exception = assertThrows<CoreException> {
+            stockService.validateStock(stock = 3, qty = 5)
+        }
+
+        assert(exception.errorType == ErrorType.OUT_OF_STOCK)
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointModelTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointModelTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
 
 class PointModelTest {
 
@@ -21,7 +22,7 @@ class PointModelTest {
             //arrange
             val userId = "testId"
             val request = PointFixture.Normal.chargeRequest(
-                amount = -2,
+                amount = BigDecimal.valueOf(-2),
             )
 
             //act

--- a/apps/commerce-api/src/test/kotlin/com/loopers/fixture/order/OrderFixture.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/fixture/order/OrderFixture.kt
@@ -18,7 +18,12 @@ sealed class OrderFixture {
                         qty = 2
                     )
                 ),
-                paymentType = PaymentType.POINT
+                payments = listOf(
+                    OrderV1Models.Request.Payment(
+                        type = PaymentType.POINT,
+                        amount = BigDecimal.valueOf(1000),
+                    )
+                )
             )
         }
     }
@@ -38,7 +43,12 @@ sealed class OrderFixture {
                         qty = 3
                     )
                 ),
-                paymentType = PaymentType.POINT
+                payments = listOf(
+                    OrderV1Models.Request.Payment(
+                        type = PaymentType.POINT,
+                        amount = BigDecimal.valueOf(1000),
+                    )
+                )
             )
         }
     }
@@ -53,7 +63,12 @@ sealed class OrderFixture {
                         qty = 1
                     )
                 ),
-                paymentType = PaymentType.POINT
+                payments = listOf(
+                    OrderV1Models.Request.Payment(
+                        type = PaymentType.POINT,
+                        amount = BigDecimal.valueOf(1000),
+                    )
+                )
             )
         }
     }
@@ -68,7 +83,12 @@ sealed class OrderFixture {
                         qty = -1
                     )
                 ),
-                paymentType = PaymentType.POINT
+                payments = listOf(
+                    OrderV1Models.Request.Payment(
+                        type = PaymentType.POINT,
+                        amount = BigDecimal.valueOf(1000),
+                    )
+                )
             )
         }
     }
@@ -77,7 +97,12 @@ sealed class OrderFixture {
         override fun create(): OrderV1Models.Request.Create {
             return OrderV1Models.Request.Create(
                 items = emptyList(),
-                paymentType = PaymentType.POINT
+                payments = listOf(
+                    OrderV1Models.Request.Payment(
+                        type = PaymentType.POINT,
+                        amount = BigDecimal.valueOf(1000),
+                    )
+                )
             )
         }
     }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/fixture/order/OrderFixture.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/fixture/order/OrderFixture.kt
@@ -1,0 +1,84 @@
+package com.loopers.fixture.order
+
+import com.loopers.domain.type.PaymentType
+import com.loopers.interfaces.api.order.OrderV1Models
+import java.math.BigDecimal
+
+sealed class OrderFixture {
+
+    abstract fun create(): OrderV1Models.Request.Create
+
+    object Normal : OrderFixture() {
+        override fun create(): OrderV1Models.Request.Create {
+            return OrderV1Models.Request.Create(
+                items = listOf(
+                    OrderV1Models.Request.Item(
+                        productId = 1L,
+                        price = BigDecimal.valueOf(1000),
+                        qty = 2
+                    )
+                ),
+                paymentType = PaymentType.POINT
+            )
+        }
+    }
+
+    object MultipleItems : OrderFixture() {
+        override fun create(): OrderV1Models.Request.Create {
+            return OrderV1Models.Request.Create(
+                items = listOf(
+                    OrderV1Models.Request.Item(
+                        productId = 1L,
+                        price = BigDecimal.valueOf(1000),
+                        qty = 1
+                    ),
+                    OrderV1Models.Request.Item(
+                        productId = 2L,
+                        price = BigDecimal.valueOf(2000),
+                        qty = 3
+                    )
+                ),
+                paymentType = PaymentType.POINT
+            )
+        }
+    }
+
+    object InvalidPrice : OrderFixture() {
+        override fun create(): OrderV1Models.Request.Create {
+            return OrderV1Models.Request.Create(
+                items = listOf(
+                    OrderV1Models.Request.Item(
+                        productId = 1L,
+                        price = BigDecimal.valueOf(-100),
+                        qty = 1
+                    )
+                ),
+                paymentType = PaymentType.POINT
+            )
+        }
+    }
+
+    object InvalidQty : OrderFixture() {
+        override fun create(): OrderV1Models.Request.Create {
+            return OrderV1Models.Request.Create(
+                items = listOf(
+                    OrderV1Models.Request.Item(
+                        productId = 1L,
+                        price = BigDecimal.valueOf(100),
+                        qty = -1
+                    )
+                ),
+                paymentType = PaymentType.POINT
+            )
+        }
+    }
+
+    object EmptyItems : OrderFixture() {
+        override fun create(): OrderV1Models.Request.Create {
+            return OrderV1Models.Request.Create(
+                items = emptyList(),
+                paymentType = PaymentType.POINT
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/fixture/point/PointFixture.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/fixture/point/PointFixture.kt
@@ -2,16 +2,17 @@ package com.loopers.fixture.point
 
 import com.loopers.domain.point.PointCommand
 import com.loopers.domain.point.PointEntity
-import com.loopers.interfaces.api.point.PointV1Dto
+import com.loopers.interfaces.api.point.PointV1Models
+import java.math.BigDecimal
 
 sealed class PointFixture {
 
     abstract val userId: String
-    abstract val amount: Long
+    abstract val amount: BigDecimal
 
     fun pointCommand(
         userId: String = this.userId,
-        amount: Long = this.amount,
+        amount: BigDecimal = this.amount,
     ): PointCommand.ChargeInput {
         return PointCommand.ChargeInput(
             userId = userId,
@@ -21,7 +22,7 @@ sealed class PointFixture {
 
     fun pointEntity(
         userId: String = this.userId,
-        amount: Long = this.amount,
+        amount: BigDecimal = this.amount,
     ): PointEntity {
         return PointEntity(
             userId = userId,
@@ -30,13 +31,13 @@ sealed class PointFixture {
     }
 
     fun chargeRequest(
-        amount: Long = this.amount,
-    ): PointV1Dto.Request.Charge {
-        return PointV1Dto.Request.Charge(amount = amount)
+        amount: BigDecimal = this.amount,
+    ): PointV1Models.Request.Charge {
+        return PointV1Models.Request.Charge(amount = amount)
     }
 
     object Normal: PointFixture() {
         override val userId = "user1"
-        override val amount= 23L
+        override val amount= BigDecimal.valueOf(23)
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/fixture/product/ProductFixture.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/fixture/product/ProductFixture.kt
@@ -1,0 +1,62 @@
+package com.loopers.fixture.product
+
+import com.loopers.domain.brand.BrandEntity
+import com.loopers.domain.product.ProductEntity
+import com.loopers.fixture.point.PointFixture
+import jakarta.persistence.Column
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import java.math.BigDecimal
+
+sealed class ProductFixture {
+
+    abstract val name: String
+    abstract val price: BigDecimal
+    abstract val stock: Int
+    abstract val likeCount: Int
+
+    fun create(brandId: Long): ProductEntity {
+        return ProductEntity(
+            name = name,
+            brandId = brandId,
+            price = price,
+            stock = stock,
+            likeCount = likeCount
+        )
+    }
+
+    fun createByPrice(
+        brandId: Long,
+        price: BigDecimal,
+    ): ProductEntity {
+        return ProductEntity(
+            name = name,
+            brandId = brandId,
+            price = price,
+            stock = stock,
+            likeCount = likeCount
+        )
+    }
+
+    fun createByLikeCount(
+        brandId: Long,
+        likeCount: Int,
+    ): ProductEntity {
+        return ProductEntity(
+            name = name,
+            brandId = brandId,
+            price = price,
+            stock = stock,
+            likeCount = likeCount
+        )
+    }
+
+    object Normal : ProductFixture() {
+        override val name = "기본 상품"
+        override val price = BigDecimal.valueOf(1000.00)
+        override val stock = 100
+        override val likeCount = 0
+    }
+}
+

--- a/apps/commerce-api/src/test/kotlin/com/loopers/fixture/user/UserFixture.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/fixture/user/UserFixture.kt
@@ -2,7 +2,8 @@ package com.loopers.fixture.user
 
 import com.loopers.domain.user.Gender
 import com.loopers.domain.user.UserCommand
-import com.loopers.interfaces.api.user.UserV1Dto
+import com.loopers.domain.user.UserEntity
+import com.loopers.interfaces.api.user.UserV1Models
 
 sealed class UserFixture {
 
@@ -30,12 +31,26 @@ sealed class UserFixture {
         birthDate: String = this.birth,
         email: String = this.email,
         gender: Gender = this.gender
-    ): UserV1Dto.Request.SignUp {
-        return UserV1Dto.Request.SignUp(
+    ): UserV1Models.Request.SignUp {
+        return UserV1Models.Request.SignUp(
             userId = userId,
             birthDate = birthDate,
             email = email,
             gender = gender
+        )
+    }
+
+    fun createUserEntity(
+        userId: String = this.userId,
+        birthDate: String = this.birth,
+        email: String = this.email,
+        gender: Gender = this.gender
+    ): UserEntity {
+        return UserEntity(
+            userId = userId,
+            birthDate = birthDate,
+            email = email,
+            gender
         )
     }
 

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/point/PointV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/point/PointV1ApiE2ETest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.assertAll
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
+import java.math.BigDecimal
 import kotlin.test.Test
 
 class PointV1ApiE2ETest(
@@ -39,7 +40,7 @@ class PointV1ApiE2ETest(
             val httpEntity = HttpEntity(null, headers)
 
             //act
-            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Dto.Response.PointResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Models.Response.Get>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_GET_POINT, HttpMethod.GET, httpEntity, responseType)
 
             //assert
@@ -57,7 +58,7 @@ class PointV1ApiE2ETest(
             val httpEntity = HttpEntity.EMPTY
 
             //act
-            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Dto.Response.PointResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Models.Response.Get>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_GET_POINT, HttpMethod.GET, httpEntity, responseType)
 
             //assert
@@ -78,13 +79,13 @@ class PointV1ApiE2ETest(
             pointRepository.save(point)
             val headers = headersWithUserId( point.userId)
             val chargeRequest = PointFixture.Normal.chargeRequest(
-                amount = 1000L
+                amount = BigDecimal.valueOf(1000L)
             )
             val httpEntity = HttpEntity(chargeRequest, headers)
             val totalAmount = point.amount.plus(chargeRequest.amount)
 
             //act
-            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Dto.Response.ChargeResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Models.Response.Charge>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_CHARGE, HttpMethod.POST, httpEntity, responseType)
 
             //assert
@@ -100,12 +101,12 @@ class PointV1ApiE2ETest(
             //arrange
             val headers = headersWithUserId("test0")
             val chargeRequest = PointFixture.Normal.chargeRequest(
-                amount = 1000L
+                amount = BigDecimal.valueOf(1000L)
             )
             val httpEntity = HttpEntity(chargeRequest, headers)
 
             //act
-            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Dto.Response.ChargeResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Models.Response.Charge>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_CHARGE, HttpMethod.POST, httpEntity, responseType)
 
             //assert

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/user/UserV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/user/UserV1ApiE2ETest.kt
@@ -35,7 +35,7 @@ class UserV1ApiE2ETest(
             val request = UserFixture.Normal.createSignUpRequest()
 
             //act
-            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Models.Response.Info>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_JOIN, HttpMethod.POST, HttpEntity(request), responseType)
 
             //assert
@@ -64,7 +64,7 @@ class UserV1ApiE2ETest(
             val httpEntity = HttpEntity(request, headers)
 
             //act
-            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Models.Response.Info>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_JOIN, HttpMethod.POST, httpEntity, responseType)
 
             //assert
@@ -86,7 +86,7 @@ class UserV1ApiE2ETest(
             //act
             val headers = headersWithUserId( savedUserCommand.userId)
             val httpEntity = HttpEntity(null, headers)
-            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Models.Response.Info>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_ME, HttpMethod.GET, httpEntity, responseType)
 
             //assert
@@ -107,7 +107,7 @@ class UserV1ApiE2ETest(
             //act
             val headers = headersWithUserId(testId)
             val httpEntity = HttpEntity(null, headers)
-            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Models.Response.Info>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_ME, HttpMethod.GET, httpEntity, responseType)
 
             //assert

--- a/modules/jpa/src/main/kotlin/com/loopers/config/jpa/JpaConfig.kt
+++ b/modules/jpa/src/main/kotlin/com/loopers/config/jpa/JpaConfig.kt
@@ -8,5 +8,5 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 @Configuration
 @EnableTransactionManagement
 @EntityScan(basePackages = ["com.loopers"])
-@EnableJpaRepositories(basePackages = ["com.loopers.infrastructure"])
+@EnableJpaRepositories(basePackages = ["com.loopers"])
 class JpaConfig

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -4,7 +4,7 @@ spring:
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 100

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -4,7 +4,7 @@ spring:
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
## 📌 Summary
상품, 브랜드, 좋아요, 주문 도메인 구현

## 💬 Review Points
* 현재 로직상 주문생성시 productHistory를 저장하고 있는데, 이후 재고차감하고 새로 productHistory 생성하게 되어서 주문생성시 넣은 productHistory와 달라집니다. 이럴때는 어떻게 해야할지 고민입니다. 참고) [orderItemService.create()](https://github.com/sue4869/e-commerce/pull/6/files#diff-2dcc31c95a5c63b321830f25c5f090f98a29bd590f5e5a0e822cdf1d0ed9a49e), [StockService.changeStock()](https://github.com/sue4869/e-commerce/pull/6/files#diff-ea6ec186bb28ab18eb87c0bec1edde1da4fbdb9b4c3e5f43526820410eb5c021)

* PaymentService로 결제서비스를 구현했는데 현재는 포인트로 하나의 결제 수단으로 취급해놓았기에 지금 구조가 맞다고 생각하는데 추후에는 포인트 차감 후 다른 결제 수단으로 해야하는 거라 이걸 어떻게 해야할지 고민입니다. [OrderFacade](https://github.com/sue4869/e-commerce/pull/6/files#diff-8293235eb3168f31bc8310ab3ee16458b49b77577229581fa3dc816d6e7e300f) -> [PaymentService](https://github.com/sue4869/e-commerce/pull/6/files#diff-d0cee95491c2a357db3e580da920964056bcef66f3a3c042faf1c20560e77fca) -> [PointCharger](https://github.com/sue4869/e-commerce/pull/6/files#diff-0ece6d0dadaee1eed01bcf23b703b3cbcd5407c7ac40fb0fa4d22afcb73e780b) 및 [IPaymentCharger](https://github.com/sue4869/e-commerce/pull/6/files#diff-27b5c5f037e11f81065041a408559e32aebdcc0d3a17c0a7b2a97fd7c327504b) 흐름도 괜찮은지 확인 부탁드려용

* 주문에 대한 멱등성이 고민됩니다. 구현은 안했지만 고민은 했어서, 제가 알아보기로는 프론트에서 멱등키를 받아서 멱등키만을 디비에 저장해놓고 비교 + 락 적용을 한다고 들었는데 실무에서도 그런가요? 

* 다른 멘토님 의견에 따르면 product_like 테이블 (user, product 매핑 테이블)이 like에만 쓰이기 때문에 범용성이 없다고 말씀하셨습니다. 그러나 저는 예를 들면 조회수와 같은 다른 것까지 포함되면 해당 디비 접근률이 너무 높아지고 안좋아진다고 생각되어서 그대로 유지했는데요 멘토님은 어떻게 생각하시는지 궁금합니다. 

* 연관관계에 대해서 질문이 있습니다. Order, OrderItem이 생명주기가 같은것은 아는데 우선 OrderItem에 orderId로 id 참조로 우선 하고 필요하면 추후 연관관계 매핑을 하려고 합니다.(지금은 연관관계 매핑을 해놓긴 했어요) id 참조만 하는 거에 대해 어떻게 생각하시나요?

* 좋아요에 대해 가장 간단한 방법으로 @Modifying을 이용한 DB 연산을 직접 사용하였습니다. 단일 sql문이라 amoic하고 db안에서 직접 증가시키므로 동시에 여러 요청이 들어와도 누적값이 꼬이지 않을꺼라 생각했습니다. 다음 과제에서 바뀔꺼라 생각했지만 지금 가장 빠른 방법이라 생각해서요. 해당 방법에 대해서 어떻게 생각하실지 궁금합니다. 참고) [ProductJpaRepository](https://github.com/sue4869/e-commerce/pull/6/files#diff-2dd9d306181eca58fc502489c775188fc59bf45458349e736bf804e7136eaee0)

* '상품 상세 조회 시 Product + Brand 정보 조합은 도메인 서비스에서 처리했다' -> 저는 상품과 브랜드는 관계가 존재한다고 생각해서 연관관계를 이용해서 쿼리로 가져오는 형태로 했는데요. 프로덕트와 브랜드를 각각 조회해서 조합하는 것을 말하는 거였을까요?

* 각 layer에 데이터들을 넘겨주는 객체들을 담는 데이터 클래스들의 네이밍에 대한 고민이 있었습니다. reqeust/response를 담는 것은 Models, 도메인으로 요청하는 데이터 클래스는 command, 요청받은 결과 값들을 담은 데이터 클래스는 dto로 했습니다. 제가 고민이었던 것은 요청받은 결과값들을 command 클래스에 넣는 것이 맞는 가?에 대한 것이었습니다. command란 말 그대로 명령어 시키는 것이라 인식했기 때문이예요. 멘토님 생각은 어떠신가요? 

* 주문 로직에서 생성, 결제, 재고차감을 지금은 한 트랜잭션으로 두었는데 분리하는 것을 염두로 만들었으며 테스트도 각각 할 수 있도록 최대한 했습니다. 사실 각각 트랜잭션을 분리하는게 맞다고 생각해요. 결제 안되었다고 재시도 없이 생성을 롤백하는 것은 비지니스 상으로 맞지 않다고 생각했기 때문입니다. ( 멘토님 생각은 어떠신가요? )하지만 지금 단계는 최대한 의존성 없도록 만들어서 틀을 만드는게 우선이라 생각해서 한 트랜잭션으로 두었음을 미리 알려드립니다.  참고)  [OrderFacade](https://github.com/sue4869/e-commerce/pull/6/files#diff-8293235eb3168f31bc8310ab3ee16458b49b77577229581fa3dc816d6e7e300f)

* 브랜드와 상품을 연관관계를 맺어놓았습니다. 이유는, 저는 브랜드가 삭제되면 상품도 삭제되어야 하고, 회사에서 제 경험상 상품 조회시 브랜드정보가 필요해서 항상 조회했어서 연관관계를 맺어야 한다고 생각했습니다. 멘토님은 어떻게 생각하시나요?